### PR TITLE
Improve hotkey parsing for string descriptors

### DIFF
--- a/src/ui/init.lua
+++ b/src/ui/init.lua
@@ -135,6 +135,33 @@ local function formatHotkeyDisplay(hotkey)
     return nil
 end
 
+local lowerKeyCodeLookup
+
+local function resolveKeyCodeFromString(name)
+    if typeof(name) ~= "string" then
+        return nil
+    end
+
+    local trimmed = name:match("^%s*(.-)%s*$")
+    if trimmed == "" then
+        return nil
+    end
+
+    local enumValue = Enum.KeyCode[trimmed]
+    if enumValue then
+        return enumValue
+    end
+
+    if not lowerKeyCodeLookup then
+        lowerKeyCodeLookup = {}
+        for _, item in ipairs(Enum.KeyCode:GetEnumItems()) do
+            lowerKeyCodeLookup[item.Name:lower()] = item
+        end
+    end
+
+    return lowerKeyCodeLookup[trimmed:lower()]
+end
+
 local function parseHotkey(hotkey)
     if not hotkey then
         return nil
@@ -146,19 +173,38 @@ local function parseHotkey(hotkey)
 
     if typeof(hotkey) == "table" then
         local key = hotkey.key or hotkey.Key
+        if typeof(key) ~= "EnumItem" then
+            key = resolveKeyCodeFromString(key)
+        end
+
         if typeof(key) == "EnumItem" then
+            local parsedModifiers = {}
             local modifiers = hotkey.modifiers or hotkey.Modifiers or {}
+
+            if typeof(modifiers) == "table" then
+                for _, modifier in ipairs(modifiers) do
+                    if typeof(modifier) == "EnumItem" then
+                        table.insert(parsedModifiers, modifier)
+                    else
+                        local resolvedModifier = resolveKeyCodeFromString(modifier)
+                        if typeof(resolvedModifier) == "EnumItem" then
+                            table.insert(parsedModifiers, resolvedModifier)
+                        end
+                    end
+                end
+            end
+
             return {
                 key = key,
-                modifiers = modifiers,
+                modifiers = parsedModifiers,
                 allowGameProcessed = hotkey.allowGameProcessed == true,
             }
         end
     end
 
     if typeof(hotkey) == "string" then
-        local upper = hotkey:upper()
-        local enumValue = Enum.KeyCode[upper]
+        local enumValue = resolveKeyCodeFromString(hotkey)
+
         if enumValue then
             return { key = enumValue, modifiers = {} }
         end

--- a/tests/ui/hotkey.spec.lua
+++ b/tests/ui/hotkey.spec.lua
@@ -171,6 +171,49 @@ return function(t)
         end)
     end)
 
+    t.test("multi-word string hotkey resolves without forced casing", function(expect)
+        withController({ hotkey = "LeftShift" }, function(controller, inputService, frame, toggles)
+            local label = frame:FindFirstChild("HotkeyLabel")
+            expect(label ~= nil):toBeTruthy()
+            expect(label.Text):toEqual("Hotkey: LeftShift")
+
+            expect(controller:isEnabled()):toEqual(false)
+
+            inputService:FireInput(Enum.KeyCode.RightShift, false)
+            expect(controller:isEnabled()):toEqual(false)
+
+            inputService:FireInput(Enum.KeyCode.LeftShift, false)
+            expect(controller:isEnabled()):toEqual(true)
+            expect(toggles[#toggles]):toEqual(true)
+        end)
+    end)
+
+    t.test("table hotkey resolves string keys, modifiers, and respects allowGameProcessed", function(expect)
+        withController({
+            hotkey = {
+                key = "leftshift",
+                modifiers = { "LeftControl" },
+                allowGameProcessed = true,
+            },
+        }, function(controller, inputService, frame, toggles)
+            local label = frame:FindFirstChild("HotkeyLabel")
+            expect(label ~= nil):toBeTruthy()
+            expect(label.Text):toEqual("Hotkey: LeftControl + LeftShift")
+
+            expect(controller:isEnabled()):toEqual(false)
+
+            inputService:FireInput(Enum.KeyCode.LeftShift, false)
+            expect(controller:isEnabled()):toEqual(false)
+
+            inputService:SetKeyDown(Enum.KeyCode.LeftControl, true)
+            inputService:FireInput(Enum.KeyCode.LeftShift, true)
+            expect(controller:isEnabled()):toEqual(true)
+            expect(toggles[#toggles]):toEqual(true)
+
+            inputService:SetKeyDown(Enum.KeyCode.LeftControl, false)
+        end)
+    end)
+
     t.test("enum hotkey toggles state on repeated presses", function(expect)
         withController({ hotkey = Enum.KeyCode.J }, function(controller, inputService, frame, toggles)
             local label = frame:FindFirstChild("HotkeyLabel")


### PR DESCRIPTION
## Summary
- add a cached case-insensitive resolver for hotkey strings and reuse it for tables and modifiers
- normalize modifier arrays so string values map to Enum.KeyCodes before wiring controller listeners
- extend the UI hotkey spec with coverage for string-based tables and regenerate the fixture source map

## Testing
- ./tests/build-place.sh

------
https://chatgpt.com/codex/tasks/task_b_68e4d92ac4d4832ab3e3ac2ad6caeab6