### PR TITLE
Add initialization progress tracking to AutoParry

### DIFF
--- a/tests/autoparry/bootstrap.spec.lua
+++ b/tests/autoparry/bootstrap.spec.lua
@@ -3,6 +3,22 @@ local Harness = require(TestHarness:WaitForChild("Harness"))
 
 local Scheduler = Harness.Scheduler
 
+local function waitForStage(scheduler, autoparry, target, maxSteps)
+    local limit = maxSteps or 40
+    local progress
+
+    for _ = 1, limit do
+        progress = autoparry.getInitProgress()
+        if progress.stage == target or progress.stage == "timeout" then
+            return progress
+        end
+
+        scheduler:wait()
+    end
+
+    error(string.format("Timed out waiting for init stage '%s'", tostring(target)), 0)
+end
+
 return function(t)
     t.test("resolves the local player once it becomes available", function(expect)
         local scheduler = Scheduler.new(1)
@@ -19,9 +35,27 @@ return function(t)
             services = services,
         })
 
+        local stages = {}
+        local connection = autoparry.onInitStatus(function(progress)
+            table.insert(stages, { stage = progress.stage, target = progress.target })
+        end)
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+
         expect(autoparry ~= nil):toBeTruthy()
         expect(players.LocalPlayer):toEqual(stubPlayer)
         expect(scheduler:clock()):toBeCloseTo(3, 1e-3)
+        expect(ready.elapsed):toBeCloseTo(3, 1e-3)
+        expect(stages[1].stage):toEqual("waiting-player")
+        expect(stages[#stages].stage):toEqual("ready")
+
+        local snapshot = autoparry.getInitProgress()
+        snapshot.stage = "mutated"
+        expect(autoparry.getInitProgress().stage):toEqual("ready")
+
+        if connection then
+            connection:Disconnect()
+        end
     end)
 
     t.test("resolves the parry remote after it is created", function(expect)
@@ -39,9 +73,31 @@ return function(t)
             services = services,
         })
 
+        local stages = {}
+        local connection = autoparry.onInitStatus(function(progress)
+            table.insert(stages, { stage = progress.stage, target = progress.target })
+        end)
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+
         expect(autoparry ~= nil):toBeTruthy()
         expect(remotes:FindFirstChild("ParryButtonPress") ~= nil):toBeTruthy()
         expect(scheduler:clock()):toBeCloseTo(4, 1e-3)
+        expect(ready.elapsed):toBeCloseTo(4, 1e-3)
+
+        local sawRemoteStage = false
+        for _, item in ipairs(stages) do
+            if item.stage == "waiting-remotes" and item.target == "remote" then
+                sawRemoteStage = true
+                break
+            end
+        end
+
+        expect(sawRemoteStage):toEqual(true)
+
+        if connection then
+            connection:Disconnect()
+        end
     end)
 
     t.test("errors after 10 seconds when the local player never appears", function(expect)
@@ -49,16 +105,24 @@ return function(t)
         local services, remotes = Harness.createBaseServices(scheduler)
         remotes:Add(Harness.createRemote())
 
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local progress = waitForStage(scheduler, autoparry, "timeout", 20)
+
+        expect(progress.stage):toEqual("timeout")
+        expect(progress.reason):toEqual("local-player")
+        expect(progress.elapsed):toBeGreaterThanOrEqual(10)
+        expect(scheduler:clock()):toBeGreaterThanOrEqual(10)
+
         local ok, err = pcall(function()
-            Harness.loadAutoparry({
-                scheduler = scheduler,
-                services = services,
-            })
+            autoparry.enable()
         end)
 
         expect(ok):toEqual(false)
         expect(err):toEqual("AutoParry: LocalPlayer unavailable")
-        expect(scheduler:clock()):toBeGreaterThanOrEqual(11)
     end)
 
     t.test("errors after 10 seconds when the remotes folder is absent", function(expect)
@@ -68,16 +132,24 @@ return function(t)
             initialLocalPlayer = { Name = "LocalPlayer" },
         })
 
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local progress = waitForStage(scheduler, autoparry, "timeout", 20)
+
+        expect(progress.stage):toEqual("timeout")
+        expect(progress.reason):toEqual("remotes-folder")
+        expect(progress.elapsed):toBeGreaterThanOrEqual(10)
+        expect(scheduler:clock()):toBeGreaterThanOrEqual(10)
+
         local ok, err = pcall(function()
-            Harness.loadAutoparry({
-                scheduler = scheduler,
-                services = services,
-            })
+            autoparry.enable()
         end)
 
         expect(ok):toEqual(false)
         expect(err):toEqual("AutoParry: ReplicatedStorage.Remotes missing")
-        expect(scheduler:clock()):toBeGreaterThanOrEqual(10)
     end)
 
     t.test("errors after 10 seconds when the parry remote never appears", function(expect)
@@ -86,15 +158,23 @@ return function(t)
             initialLocalPlayer = { Name = "LocalPlayer" },
         })
 
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local progress = waitForStage(scheduler, autoparry, "timeout", 20)
+
+        expect(progress.stage):toEqual("timeout")
+        expect(progress.reason):toEqual("parry-remote")
+        expect(progress.elapsed):toBeGreaterThanOrEqual(10)
+        expect(scheduler:clock()):toBeGreaterThanOrEqual(10)
+
         local ok, err = pcall(function()
-            Harness.loadAutoparry({
-                scheduler = scheduler,
-                services = services,
-            })
+            autoparry.enable()
         end)
 
         expect(ok):toEqual(false)
         expect(err):toEqual("AutoParry: ParryButtonPress remote missing")
-        expect(scheduler:clock()):toBeGreaterThanOrEqual(10)
     end)
 end


### PR DESCRIPTION
## Summary
- introduce an initialization progress signal, expose subscription helpers, and gate heartbeat start until the parry runtime is ready
- ensure AutoParry.destroy resets the new initialization state and signal
- expand bootstrap tests to follow the staged initialization flow and regenerate the source map fixture to mirror the new runtime

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e4dfc6415c832a9c0b1dc45905be04