### PR TITLE
Enhance parry remote handling and specs

### DIFF
--- a/src/core/autoparry.lua
+++ b/src/core/autoparry.lua
@@ -10,12 +10,34 @@ local Stats = game:GetService("Stats")
 local Require = rawget(_G, "ARequire")
 local Util = Require("src/shared/util.lua")
 
+local luauTypeof = rawget(_G, "typeof")
+local arrayUnpack = table.unpack or unpack
+
+local function typeOf(value)
+    if luauTypeof then
+        local ok, result = pcall(luauTypeof, value)
+        if ok then
+            return result
+        end
+    end
+
+    return type(value)
+end
+
 local function clone(tbl)
     return Util.deepCopy(tbl)
 end
 
 local initStatus = Util.Signal.new()
 local initProgress = { stage = "waiting-player" }
+
+local function createArray(count)
+    if table.create then
+        return table.create(count)
+    end
+
+    return {}
+end
 
 local function updateInitProgress(stage, details)
     for key in pairs(initProgress) do
@@ -92,12 +114,31 @@ local function resolveParryRemote(report)
 
     assert(remotes, "AutoParry: ReplicatedStorage.Remotes missing")
 
-    report("waiting-remotes", { target = "remote", elapsed = 0 })
+    local candidateDefinitions = {
+        { name = "ParryButtonPress", variant = "modern" },
+        { name = "ParryAttempt", variant = "legacy" },
+    }
 
-    local remote = remotes:FindFirstChild("ParryButtonPress")
-    if not remote then
+    report("waiting-remotes", { target = "remote", elapsed = 0, candidates = { "ParryButtonPress", "ParryAttempt" } })
+
+    local selectedCandidate
+    local remote
+
+    local function findCandidate()
+        for _, candidate in ipairs(candidateDefinitions) do
+            local found = remotes:FindFirstChild(candidate.name)
+            if found then
+                remote = found
+                selectedCandidate = candidate
+                return true
+            end
+        end
+        return false
+    end
+
+    if not findCandidate() then
         local start = os.clock()
-        while not remote do
+        while not findCandidate() do
             local elapsed = os.clock() - start
             if elapsed >= 10 then
                 report("timeout", {
@@ -105,6 +146,7 @@ local function resolveParryRemote(report)
                     target = "remote",
                     elapsed = elapsed,
                     reason = "parry-remote",
+                    candidates = { "ParryButtonPress", "ParryAttempt" },
                 })
                 break
             end
@@ -112,18 +154,294 @@ local function resolveParryRemote(report)
             report("waiting-remotes", {
                 target = "remote",
                 elapsed = elapsed,
+                candidates = { "ParryButtonPress", "ParryAttempt" },
             })
             task.wait()
-            remote = remotes:FindFirstChild("ParryButtonPress")
         end
     end
 
-    assert(remote, "AutoParry: ParryButtonPress remote missing")
-    return remote
+    assert(remote and selectedCandidate, "AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+
+    local function isCallable(value)
+        return typeOf(value) == "function"
+    end
+
+    local adapters = {
+        { method = "FireServer", kind = "RemoteEvent" },
+        { method = "InvokeServer", kind = "RemoteFunction" },
+        { method = "Fire", kind = "BindableEvent" },
+        { method = "Invoke", kind = "BindableFunction" },
+    }
+
+    for _, adapter in ipairs(adapters) do
+        local ok, method = pcall(function()
+            return remote[adapter.method]
+        end)
+
+        if ok and isCallable(method) then
+            local methodName = adapter.method
+
+            local function fire(...)
+                local current = remote[methodName]
+                if not isCallable(current) then
+                    error(
+                        string.format(
+                            "AutoParry: parry remote missing %s",
+                            methodName
+                        ),
+                        0
+                    )
+                end
+
+                return current(remote, ...)
+            end
+
+            return remote, fire, {
+                method = methodName,
+                kind = adapter.kind,
+                className = remote.ClassName,
+                remoteName = remote.Name,
+                variant = selectedCandidate and selectedCandidate.variant or nil,
+            }
+        end
+    end
+
+    local className
+    local okClass, value = pcall(function()
+        return remote.ClassName
+    end)
+    if okClass then
+        className = value
+    end
+
+    if not className then
+        if luauTypeof then
+            local success, typeName = pcall(luauTypeof, remote)
+            if success then
+                className = typeName
+            end
+        end
+
+        if not className then
+            className = type(remote)
+        end
+    end
+
+    report("error", {
+        stage = "waiting-remotes",
+        target = "remote",
+        reason = "parry-remote-unsupported",
+        className = className,
+    })
+
+    error(
+        string.format(
+            "AutoParry: parry remote unsupported type (%s)",
+            className
+        ),
+        0
+    )
+end
+
+local function capturePlayerState(player)
+    local state = {
+        userId = player and player.UserId or 0,
+    }
+
+    local character = player and player.Character
+    if character then
+        state.character = character
+        local primary = character.PrimaryPart
+        if primary then
+            local okPosition, position = pcall(function()
+                return primary.Position
+            end)
+
+            if okPosition then
+                state.position = position
+            end
+
+            local okVelocity, velocity = pcall(function()
+                return primary.AssemblyLinearVelocity
+            end)
+
+            if okVelocity then
+                state.velocity = velocity
+            end
+
+            local okCFrame, rootCFrame = pcall(function()
+                return primary.CFrame
+            end)
+
+            if okCFrame then
+                state.cframe = rootCFrame
+            end
+        end
+    end
+
+    return state
+end
+
+local function snapshotPlayers()
+    local snapshot = {}
+    local seen = {}
+
+    local function append(player)
+        if not player or seen[player] then
+            return
+        end
+
+        seen[player] = true
+        snapshot[player.Name or tostring(player)] = capturePlayerState(player)
+    end
+
+    if Players and typeOf(Players.GetPlayers) == "function" then
+        local ok, roster = pcall(Players.GetPlayers, Players)
+        if ok and type(roster) == "table" then
+            for _, player in ipairs(roster) do
+                append(player)
+            end
+        end
+    end
+
+    if Players and Players.LocalPlayer then
+        append(Players.LocalPlayer)
+    end
+
+    return snapshot
+end
+
+local function computeBallCFrame(ball, fallbackPosition)
+    if not ball then
+        return CFrame.new(fallbackPosition or Vector3.new())
+    end
+
+    local okExisting, existing = pcall(function()
+        return ball.CFrame
+    end)
+
+    if okExisting and typeOf(existing) == "CFrame" then
+        return existing
+    end
+
+    local position
+    local okPosition, value = pcall(function()
+        return ball.Position
+    end)
+
+    if okPosition and typeOf(value) == "Vector3" then
+        position = value
+    else
+        position = fallbackPosition or Vector3.new()
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball.AssemblyLinearVelocity
+    end)
+
+    if okVelocity and typeOf(velocity) == "Vector3" and velocity.Magnitude > 1e-3 then
+        return CFrame.new(position, position + velocity.Unit)
+    end
+
+    return CFrame.new(position)
+end
+
+local legacyPayloadBuilder = nil
+local randomGenerator = typeOf(Random) == "table" and Random.new() or nil
+
+local function randomInteger(minimum, maximum)
+    if randomGenerator then
+        return randomGenerator:NextInteger(minimum, maximum)
+    end
+
+    return math.random(minimum, maximum)
+end
+
+local function buildLegacyPayload(context)
+    local builder = legacyPayloadBuilder
+    if builder then
+        local payload = builder(context)
+        assert(type(payload) == "table", "legacy payload builder must return an array of arguments")
+        return payload
+    end
+
+    local payload = createArray(5)
+    payload[1] = context.timestamp
+    payload[2] = context.ballCFrame
+    payload[3] = context.playersSnapshot
+    payload[4] = randomInteger(100000, 999999999)
+    payload[5] = randomInteger(100000, 999999999)
+    payload.n = 5
+    return payload
+end
+
+local function createLegacyContext(ball, analysis)
+    local now = os.clock()
+    local rootPosition = analysis and analysis.rootPosition or nil
+    local ballPosition
+    local okPosition, value = pcall(function()
+        return ball and ball.Position
+    end)
+    if okPosition and typeOf(value) == "Vector3" then
+        ballPosition = value
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball and ball.AssemblyLinearVelocity
+    end)
+    if not okVelocity or typeOf(velocity) ~= "Vector3" then
+        velocity = Vector3.new()
+    end
+
+    local tti = analysis and analysis.tti or 0
+
+    return {
+        timestamp = now,
+        ball = ball,
+        ballPosition = ballPosition or Vector3.new(),
+        ballVelocity = velocity,
+        ballCFrame = computeBallCFrame(ball, rootPosition),
+        rootPosition = rootPosition,
+        predictedImpact = now + math.max(tti, 0),
+        ping = analysis and analysis.ping or 0,
+        tti = tti,
+        localPlayer = LocalPlayer,
+        playersSnapshot = snapshotPlayers(),
+    }
+end
+
+local function configureParryRemoteInvoker(remoteInfo)
+    if not ParryRemoteBaseFire then
+        ParryRemoteFire = nil
+        return
+    end
+
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
+    if not variant and ParryRemote then
+        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
+    end
+
+    ParryRemoteVariant = variant
+
+    if variant == "legacy" then
+        ParryRemoteFire = function(ball, analysis)
+            local context = createLegacyContext(ball, analysis)
+            local payload = buildLegacyPayload(context)
+            local length = payload.n or #payload
+            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
+        end
+    else
+        ParryRemoteFire = function()
+            return ParryRemoteBaseFire()
+        end
+    end
 end
 
 local LocalPlayer = nil
 local ParryRemote = nil
+local ParryRemoteFire = nil
+local ParryRemoteVariant = nil
+local ParryRemoteBaseFire = nil
 
 local initialization = {
     started = false,
@@ -138,6 +456,10 @@ local function beginInitialization()
     initialization.started = true
     initialization.completed = false
     initialization.error = nil
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
 
     updateInitProgress("waiting-player", { elapsed = 0 })
 
@@ -152,14 +474,14 @@ local function beginInitialization()
             updateInitProgress(stage, details)
         end
 
-        local ok, player, remoteOrError = pcall(function()
+        local ok, player, remoteOrError, fire, remoteInfo = pcall(function()
             local player = resolveLocalPlayer(report)
             if initialization.token ~= token then
-                return nil, nil
+                return nil, nil, nil, nil
             end
 
-            local remote = resolveParryRemote(report)
-            return player, remote
+            local remote, parryFire, info = resolveParryRemote(report)
+            return player, remote, parryFire, info
         end)
 
         if initialization.token ~= token then
@@ -167,16 +489,74 @@ local function beginInitialization()
         end
 
         if ok then
-            if not player or not remoteOrError then
+            if not player or not remoteOrError or not fire then
                 return
             end
 
             LocalPlayer = player
             ParryRemote = remoteOrError
+            ParryRemoteBaseFire = fire
+            ParryRemoteVariant = remoteInfo and remoteInfo.variant or nil
+            configureParryRemoteInvoker(remoteInfo)
             initialization.completed = true
-            report("ready", { elapsed = os.clock() - initStart })
+            local readyDetails = { elapsed = os.clock() - initStart }
+
+            if remoteInfo then
+                if remoteInfo.kind then
+                    readyDetails.remoteKind = remoteInfo.kind
+                end
+
+                if remoteInfo.method then
+                    readyDetails.remoteMethod = remoteInfo.method
+                end
+
+                if remoteInfo.className then
+                    readyDetails.remoteClass = remoteInfo.className
+                end
+
+                if remoteInfo.remoteName then
+                    readyDetails.remoteName = remoteInfo.remoteName
+                end
+
+                if remoteInfo.variant then
+                    readyDetails.remoteVariant = remoteInfo.variant
+                end
+            end
+
+            if not readyDetails.remoteClass then
+                local okClass, className = pcall(function()
+                    return ParryRemote.ClassName
+                end)
+
+                if okClass then
+                    readyDetails.remoteClass = className
+                end
+            end
+
+            report("ready", readyDetails)
         else
             initialization.error = player
+            local details = { message = player }
+
+            if initProgress.stage == "error" then
+                if initProgress.reason then
+                    details.reason = initProgress.reason
+                end
+
+                if initProgress.target then
+                    details.target = initProgress.target
+                end
+
+                if initProgress.className then
+                    details.className = initProgress.className
+                end
+
+                if initProgress.elapsed then
+                    details.elapsed = initProgress.elapsed
+                end
+            end
+
+            report("error", details)
         end
     end)
 end
@@ -282,14 +662,16 @@ local function emitState()
     stateChanged:fire(state.enabled)
 end
 
-local function tryParry(ball)
+local function tryParry(ball, analysis)
     local now = os.clock()
     if now - state.lastParry < config.cooldown then
         return false
     end
 
     state.lastParry = now
-    ParryRemote:FireServer()
+
+    assert(ParryRemoteFire, "AutoParry: Parry remote unavailable")
+    ParryRemoteFire(ball, analysis)
     parryEvent:fire(ball, now)
     log("AutoParry: fired parry for", ball)
     return true
@@ -312,7 +694,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local toPlayer = (rootPos - ball.Position)
     if toPlayer.Magnitude == 0 then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = toPlayer.Magnitude,
+            velocity = velocity,
+        }
     end
 
     local toward = velocity:Dot(toPlayer.Unit)
@@ -322,7 +712,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local distanceToPlayer = distance(ball.Position, rootPos)
     if distanceToPlayer <= config.safeRadius then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = distanceToPlayer,
+            velocity = velocity,
+        }
     end
 
     local tti = distanceToPlayer / toward
@@ -332,7 +730,15 @@ local function evaluateBall(ball, rootPos, ping)
         return nil
     end
 
-    return tti
+    return {
+        ball = ball,
+        rootPosition = rootPos,
+        ping = ping,
+        tti = tti,
+        immediate = false,
+        distance = distanceToPlayer,
+        velocity = velocity,
+    }
 end
 
 local function step()
@@ -351,23 +757,24 @@ local function step()
     end
 
     local rootPos = character.PrimaryPart.Position
-    local bestBall, bestTti
+    local bestAnalysis
     local ping = currentPing()
 
     for _, ball in ipairs(folder:GetChildren()) do
-        local tti = evaluateBall(ball, rootPos, ping)
-        if tti == 0 then
-            if tryParry(ball) then
-                return
+        local analysis = evaluateBall(ball, rootPos, ping)
+        if analysis then
+            if analysis.tti == 0 then
+                if tryParry(ball, analysis) then
+                    return
+                end
+            elseif not bestAnalysis or analysis.tti < bestAnalysis.tti then
+                bestAnalysis = analysis
             end
-        elseif tti and (not bestTti or tti < bestTti) then
-            bestTti = tti
-            bestBall = ball
         end
     end
 
-    if bestBall then
-        tryParry(bestBall)
+    if bestAnalysis then
+        tryParry(bestAnalysis.ball, bestAnalysis)
     end
 end
 
@@ -511,6 +918,18 @@ function AutoParry.setLogger(fn)
     logger = fn
 end
 
+function AutoParry.setLegacyPayloadBuilder(builder)
+    if builder ~= nil then
+        assert(type(builder) == "function", "AutoParry.setLegacyPayloadBuilder expects a function or nil")
+    end
+
+    legacyPayloadBuilder = builder
+
+    if ParryRemoteVariant == "legacy" and ParryRemoteBaseFire then
+        configureParryRemoteInvoker({ variant = ParryRemoteVariant })
+    end
+end
+
 function AutoParry.destroy()
     AutoParry.disable()
     stateChanged:destroy()
@@ -526,6 +945,9 @@ function AutoParry.destroy()
 
     LocalPlayer = nil
     ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
 
     for key in pairs(initProgress) do
         initProgress[key] = nil

--- a/tests/autoparry/bootstrap.spec.lua
+++ b/tests/autoparry/bootstrap.spec.lua
@@ -27,7 +27,7 @@ return function(t)
 
         local stubPlayer = { Name = "LocalPlayer" }
         scheduler:schedule(3, function()
-            players.LocalPlayer = stubPlayer
+            players:_setLocalPlayer(stubPlayer)
         end)
 
         local autoparry = Harness.loadAutoparry({
@@ -84,6 +84,8 @@ return function(t)
         expect(remotes:FindFirstChild("ParryButtonPress") ~= nil):toBeTruthy()
         expect(scheduler:clock()):toBeCloseTo(4, 1e-3)
         expect(ready.elapsed):toBeCloseTo(4, 1e-3)
+        expect(ready.remoteName):toEqual("ParryButtonPress")
+        expect(ready.remoteVariant):toEqual("modern")
 
         local sawRemoteStage = false
         for _, item in ipairs(stages) do
@@ -175,6 +177,55 @@ return function(t)
         end)
 
         expect(ok):toEqual(false)
-        expect(err):toEqual("AutoParry: ParryButtonPress remote missing")
+        expect(err):toEqual("AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+    end)
+
+    t.test("errors when the parry remote lacks a supported fire method", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        local invalidRemote = { Name = "ParryButtonPress", ClassName = "Folder" }
+        remotes:Add(invalidRemote)
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local progress = waitForStage(scheduler, autoparry, "error", 20)
+
+        expect(progress.stage):toEqual("error")
+        expect(progress.target):toEqual("remote")
+        expect(progress.reason):toEqual("parry-remote-unsupported")
+        expect(progress.className):toEqual("Folder")
+        expect(progress.message):toEqual("AutoParry: parry remote unsupported type (Folder)")
+
+        local ok, err = pcall(function()
+            autoparry.enable()
+        end)
+
+        expect(ok):toEqual(false)
+        expect(err):toEqual("AutoParry: parry remote unsupported type (Folder)")
+    end)
+
+    t.test("falls back to the legacy parry attempt remote when the button press is missing", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        remotes:Add(Harness.createRemote({ name = "ParryAttempt" }))
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+
+        expect(ready.remoteName):toEqual("ParryAttempt")
+        expect(ready.remoteVariant):toEqual("legacy")
     end)
 end

--- a/tests/autoparry/evaluate_ball.spec.lua
+++ b/tests/autoparry/evaluate_ball.spec.lua
@@ -208,6 +208,13 @@ local function computeExpectedTti(ball, rootPosition, pingSeconds, config)
     return rawTti - (pingSeconds + config.pingOffset)
 end
 
+local function assertAnalysis(expect, analysis, ball, rootPosition)
+    expect(analysis ~= nil):toBeTruthy()
+    expect(analysis.ball).toEqual(ball)
+    expect(analysis.rootPosition).toEqual(rootPosition)
+    return analysis.tti
+end
+
 return function(t)
     t.test("evaluateBall rejects clones that are not BaseParts", function(expect)
         local context = createContext()
@@ -219,8 +226,8 @@ return function(t)
             :withName("NotBasePart")
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -229,8 +236,8 @@ return function(t)
         local builder = BallBuilder.new(context.config)
         local ball = builder:withRealBall(false):build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -242,8 +249,8 @@ return function(t)
             :withVelocity(Vector3.new(0, 0, -slowSpeed))
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -254,8 +261,10 @@ return function(t)
             :withPosition(context.rootPosition)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
         expect(tti):toEqual(0)
+        expect(analysis.immediate):toEqual(true)
         context.autoparry.destroy()
     end)
 
@@ -267,8 +276,8 @@ return function(t)
             :withVelocity(awayVelocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -280,8 +289,8 @@ return function(t)
             :withVelocity(sidewaysVelocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -296,8 +305,10 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
         expect(tti):toEqual(0)
+        expect(analysis.immediate):toEqual(true)
         context.autoparry.destroy()
     end)
 
@@ -311,8 +322,8 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -327,8 +338,8 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -345,8 +356,8 @@ return function(t)
             :build(context.ballsFolder)
 
         local pingSeconds = 0.01
-        local tti = context.evaluateBall(ball, context.rootPosition, pingSeconds)
-        expect(tti ~= nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, pingSeconds)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
 
         local expected = computeExpectedTti(ball, context.rootPosition, pingSeconds, context.config)
         expect(tti):toBeCloseTo(expected, 1e-3)
@@ -371,8 +382,8 @@ return function(t)
             )
 
             local ball = builder:withVelocity(velocity):build(context.ballsFolder)
-            local tti = context.evaluateBall(ball, context.rootPosition, 0)
-            expect(tti == nil):toBeTruthy()
+            local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+            expect(analysis == nil):toBeTruthy()
         end
 
         context.autoparry.destroy()
@@ -394,8 +405,8 @@ return function(t)
             )
 
             local ball = builder:withVelocity(velocity):build(context.ballsFolder)
-            local tti = context.evaluateBall(ball, context.rootPosition, 0)
-            expect(tti ~= nil):toBeTruthy()
+            local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+            local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
 
             local expected = computeExpectedTti(ball, context.rootPosition, 0, context.config)
             expect(tti):toBeCloseTo(expected, 1e-3)

--- a/tests/autoparry/parry_loop.spec.lua
+++ b/tests/autoparry/parry_loop.spec.lua
@@ -8,10 +8,22 @@ local Scheduler = Harness.Scheduler
 local function createBall(options)
     options = options or {}
 
+    local position = options.position or Vector3.new()
+    local velocity = options.velocity or Vector3.new(0, 0, -140)
+
+    local function computeCFrame(pos, vel)
+        if vel and vel.Magnitude > 1e-3 then
+            return CFrame.new(pos, pos + vel.Unit)
+        end
+
+        return CFrame.new(pos)
+    end
+
     local ball = {
         Name = options.name or "TestBall",
-        Position = options.position or Vector3.new(),
-        AssemblyLinearVelocity = options.velocity or Vector3.new(0, 0, -140),
+        Position = position,
+        AssemblyLinearVelocity = velocity,
+        CFrame = options.cframe or computeCFrame(position, velocity),
         Parent = nil,
         _isReal = options.realBall ~= false,
         _attributes = {},
@@ -37,12 +49,14 @@ local function createBall(options)
         return self._attributes[name]
     end
 
-    function ball:SetPosition(position)
-        self.Position = position
+    function ball:SetPosition(newPosition)
+        self.Position = newPosition
+        self.CFrame = computeCFrame(newPosition, self.AssemblyLinearVelocity)
     end
 
-    function ball:SetVelocity(velocity)
-        self.AssemblyLinearVelocity = velocity
+    function ball:SetVelocity(newVelocity)
+        self.AssemblyLinearVelocity = newVelocity
+        self.CFrame = computeCFrame(self.Position, newVelocity)
     end
 
     function ball:SetRealBall(value)
@@ -121,14 +135,32 @@ local function createRunServiceStub()
     return stub
 end
 
-local function createContext()
+local luauTypeof = rawget(_G, "typeof")
+
+local function isCallable(value)
+    if luauTypeof then
+        local ok, kind = pcall(luauTypeof, value)
+        if ok and kind == "function" then
+            return true
+        end
+    end
+
+    return type(value) == "function"
+end
+
+local function createContext(options)
+    options = options or {}
     local scheduler = Scheduler.new(1 / 120)
     local runService = createRunServiceStub()
 
     local highlightEnabled = true
     local highlight = { Name = "Highlight" }
 
-    local rootPart = { Position = Vector3.new() }
+    local rootPart = {
+        Position = Vector3.new(),
+        AssemblyLinearVelocity = Vector3.new(),
+        CFrame = CFrame.new(),
+    }
     local character
 
     character = {
@@ -158,7 +190,7 @@ local function createContext()
         stats = stats,
     })
 
-    local remote = Harness.createRemote()
+    local remote = Harness.createRemote(options.remote)
     remotes:Add(remote)
 
     local ballsFolder = BallsFolder.new("Balls")
@@ -188,14 +220,17 @@ local function createContext()
     end
 
     local remoteLog = {}
-    local originalFireServer = remote.FireServer
+    local parryMethodName = remote._parryMethod or "FireServer"
+    local originalParryMethod = remote[parryMethodName]
 
-    function remote:FireServer(...)
+    assert(isCallable(originalParryMethod), "Harness remote missing parry method")
+
+    remote[parryMethodName] = function(self, ...)
         table.insert(remoteLog, {
             timestamp = scheduler:clock(),
             payload = { ... },
         })
-        return originalFireServer(self, ...)
+        return originalParryMethod(self, ...)
     end
 
     local parryLog = {}
@@ -211,6 +246,7 @@ local function createContext()
         runService = runService,
         autoparry = autoparry,
         remote = remote,
+        remoteMethod = parryMethodName,
         remoteLog = remoteLog,
         parryLog = parryLog,
         ballsFolder = ballsFolder,
@@ -253,7 +289,7 @@ local function createContext()
         autoparry.destroy()
         -- selene: allow(incorrect_standard_library_use)
         os.clock = originalClock
-        remote.FireServer = originalFireServer
+        remote[parryMethodName] = originalParryMethod
         if originalWorkspace == nil then
             rawset(_G, "workspace", nil)
         else
@@ -362,6 +398,87 @@ return function(t)
 
         expect(#context.parryLog).toEqual(1)
         expect(context.parryLog[1].ball).toEqual(ball)
+
+        context:destroy()
+    end)
+
+    t.test("parry loop fires bindable parry remotes", function(expect)
+        local context = createContext({
+            remote = {
+                kind = "BindableEvent",
+            },
+        })
+
+        local autoparry = context.autoparry
+
+        autoparry.resetConfig()
+        autoparry.configure({
+            minTTI = 0,
+            pingOffset = 0,
+            cooldown = 0.12,
+        })
+
+        local ball = context:addBall({
+            name = "BindableThreat",
+            position = Vector3.new(0, 0, 36),
+            velocity = Vector3.new(0, 0, -180),
+        })
+
+        autoparry.setEnabled(true)
+        context:step(1 / 60)
+
+        expect(#context.parryLog).toEqual(1)
+        expect(context.parryLog[1].ball).toEqual(ball)
+        expect(context.remoteMethod).toEqual("Fire")
+        expect(#context.remoteLog).toEqual(1)
+        expect(context.remote.lastPayload).toEqual({})
+
+        context:destroy()
+    end)
+
+    t.test("parry loop builds a legacy parry attempt payload", function(expect)
+        local context = createContext({
+            remote = {
+                name = "ParryAttempt",
+                kind = "RemoteEvent",
+            },
+        })
+
+        local autoparry = context.autoparry
+
+        autoparry.resetConfig()
+        autoparry.configure({
+            minTTI = 0,
+            pingOffset = 0,
+            cooldown = 0.12,
+        })
+
+        local ball = context:addBall({
+            name = "LegacyThreat",
+            position = Vector3.new(0, 0, 36),
+            velocity = Vector3.new(0, 0, -180),
+        })
+
+        autoparry.setEnabled(true)
+        context:step(1 / 60)
+
+        expect(#context.parryLog).toEqual(1)
+        expect(context.parryLog[1].ball).toEqual(ball)
+        expect(context.remoteMethod).toEqual("FireServer")
+
+        local payload = context.remote.lastPayload
+        expect(#payload).toEqual(5)
+        expect(type(payload[1])).toEqual("number")
+        expect(payload[2]).toEqual(ball.CFrame)
+        expect(type(payload[4])).toEqual("number")
+        expect(type(payload[5])).toEqual("number")
+
+        local snapshot = payload[3]
+        expect(type(snapshot)).toEqual("table")
+        local localEntry = snapshot["LocalPlayer"]
+        expect(type(localEntry)).toEqual("table")
+        expect(localEntry.position).toEqual(context.rootPart.Position)
+        expect(localEntry.velocity).toEqual(context.rootPart.AssemblyLinearVelocity)
 
         context:destroy()
     end)

--- a/tests/autoparry/ping.spec.lua
+++ b/tests/autoparry/ping.spec.lua
@@ -87,13 +87,15 @@ return function(t)
         for index, scenario in ipairs(scenarios) do
             local pingSeconds = currentPing()
             local ball = makeBall(15, 45)
-            local tti = evaluateBall(ball, rootPosition, pingSeconds)
+            local analysis = evaluateBall(ball, rootPosition, pingSeconds)
 
-            expect(tti ~= nil):toBeTruthy()
+            expect(analysis ~= nil):toBeTruthy()
 
+            local tti = analysis.tti
             local expectedAdjustment = pingSeconds + config.pingOffset
             local expectedTti = baseTti - expectedAdjustment
             expect(tti):toBeCloseTo(expectedTti, 1e-3)
+            expect(analysis.ping):toEqual(pingSeconds)
 
             table.insert(observations, {
                 sequence = index,


### PR DESCRIPTION
## Summary
- broaden parry remote discovery to recognize the legacy ParryAttempt remote, build realistic payloads, and surface more metadata during initialization while allowing custom payload builders
- enrich ball evaluation data and parry loop wiring so parry attempts carry context for the configured remote variant
- update the harness and specs to track player rosters, ball CFrames, and assert the legacy payload along with new init progress details

## Testing
- selene src tests *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e51b61146c832a976037acd1a50385