### PR TITLE
Handle parry remote loss and restart initialization

### DIFF
--- a/src/core/autoparry.lua
+++ b/src/core/autoparry.lua
@@ -10,12 +10,281 @@ local Stats = game:GetService("Stats")
 local Require = rawget(_G, "ARequire")
 local Util = Require("src/shared/util.lua")
 
+local luauTypeof = rawget(_G, "typeof")
+local arrayUnpack = table.unpack or unpack
+
+local function typeOf(value)
+    if luauTypeof then
+        local ok, result = pcall(luauTypeof, value)
+        if ok then
+            return result
+        end
+    end
+
+    return type(value)
+end
+
+local function isCallable(value)
+    return typeOf(value) == "function"
+end
+
+local function safeDisconnect(connection)
+    if not connection then
+        return
+    end
+
+    local okMethod, disconnectMethod = pcall(function()
+        return connection.Disconnect or connection.disconnect
+    end)
+
+    if okMethod and isCallable(disconnectMethod) then
+        pcall(disconnectMethod, connection)
+    end
+end
+
+local function connectClientEvent(remote, handler)
+    if not remote or not handler then
+        return nil
+    end
+
+    local okEvent, event = pcall(function()
+        return remote.OnClientEvent
+    end)
+    if not okEvent or event == nil then
+        return nil
+    end
+
+    local okConnect, connection = pcall(function()
+        return event:Connect(handler)
+    end)
+    if okConnect and connection then
+        return connection
+    end
+
+    local okMethod, connectMethod = pcall(function()
+        return event.Connect or event.connect
+    end)
+    if okMethod and isCallable(connectMethod) then
+        local success, result = pcall(connectMethod, event, handler)
+        if success then
+            return result
+        end
+    end
+
+    return nil
+end
+
+local function connectSignal(signal, handler)
+    if not signal or not handler then
+        return nil
+    end
+
+    local okMethod, connectMethod = pcall(function()
+        return signal.Connect or signal.connect
+    end)
+
+    if okMethod and isCallable(connectMethod) then
+        local success, connection = pcall(connectMethod, signal, handler)
+        if success then
+            return connection
+        end
+    end
+
+    return nil
+end
+
+local function connectInstanceEvent(instance, eventName, handler)
+    if not instance or not handler then
+        return nil
+    end
+
+    local okEvent, event = pcall(function()
+        return instance[eventName]
+    end)
+
+    if not okEvent or event == nil then
+        return nil
+    end
+
+    return connectSignal(event, handler)
+end
+
+local function connectPropertyChangedSignal(instance, propertyName, handler)
+    if not instance or not handler then
+        return nil
+    end
+
+    local okGetter, getSignal = pcall(function()
+        return instance.GetPropertyChangedSignal
+    end)
+
+    if not okGetter or not isCallable(getSignal) then
+        return nil
+    end
+
+    local okSignal, signal = pcall(getSignal, instance, propertyName)
+    if not okSignal or signal == nil then
+        return nil
+    end
+
+    return connectSignal(signal, handler)
+end
+
+local function getClassName(instance)
+    if instance == nil then
+        return "nil"
+    end
+
+    local okClass, className = pcall(function()
+        return instance.ClassName
+    end)
+    if okClass and type(className) == "string" then
+        return className
+    end
+
+    local okType, typeName = pcall(typeOf, instance)
+    if okType and type(typeName) == "string" then
+        return typeName
+    end
+
+    return type(instance)
+end
+
+local function isRemoteEvent(remote)
+    if remote == nil then
+        return false, "nil"
+    end
+
+    local okIsA, result = pcall(function()
+        local method = remote.IsA
+        if not isCallable(method) then
+            return nil
+        end
+        return method(remote, "RemoteEvent")
+    end)
+
+    if okIsA and result == true then
+        return true, getClassName(remote)
+    end
+
+    local className = getClassName(remote)
+    if className == "RemoteEvent" then
+        return true, className
+    end
+
+    return false, className
+end
+
+local function locateSuccessRemotes(remotes)
+    local success = {}
+    if not remotes or typeOf(remotes.FindFirstChild) ~= "function" then
+        return success
+    end
+
+    local definitions = {
+        { key = "ParrySuccess", name = "ParrySuccess" },
+        { key = "ParrySuccessAll", name = "ParrySuccessAll" },
+    }
+
+    for _, definition in ipairs(definitions) do
+        local okRemote, remote = pcall(remotes.FindFirstChild, remotes, definition.name)
+        if okRemote and remote then
+            local isEvent = isRemoteEvent(remote)
+            if isEvent then
+                success[definition.key] = { remote = remote, name = definition.name }
+            end
+        end
+    end
+
+    return success
+end
+
+local function createRemoteFireWrapper(remote, methodName)
+    return function(...)
+        local current = remote[methodName]
+        if not isCallable(current) then
+            error(
+                string.format(
+                    "AutoParry: parry remote missing %s",
+                    methodName
+                ),
+                0
+            )
+        end
+
+        return current(remote, ...)
+    end
+end
+
+local function findRemoteFire(remote)
+    local okServer, fireServer = pcall(function()
+        return remote.FireServer
+    end)
+    if okServer and isCallable(fireServer) then
+        return "FireServer", createRemoteFireWrapper(remote, "FireServer")
+    end
+
+    local okFire, fire = pcall(function()
+        return remote.Fire
+    end)
+    if okFire and isCallable(fire) then
+        return "Fire", createRemoteFireWrapper(remote, "Fire")
+    end
+
+    return nil, nil
+end
+
 local function clone(tbl)
     return Util.deepCopy(tbl)
 end
 
+local function deferTask(callback)
+    local okDefer, deferImpl = pcall(function()
+        return task.defer
+    end)
+
+    if okDefer and isCallable(deferImpl) then
+        return deferImpl(callback)
+    end
+
+    return task.spawn(callback)
+end
+
 local initStatus = Util.Signal.new()
 local initProgress = { stage = "waiting-player" }
+
+local state
+local parrySuccessSignal
+local parryBroadcastSignal
+local ParrySuccessConnection = nil
+local ParrySuccessAllConnection = nil
+local ParrySuccessRemote = nil
+local ParrySuccessAllRemote = nil
+local configureSuccessListeners
+local disconnectSuccessListeners
+local monitorParryRemote
+local handleParryRemoteInvalidated
+local disconnectParryRemoteMonitors
+local scheduleParryRemoteRestart
+
+local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress", "ParryAttempt" }
+
+local function disconnectSuccessListeners()
+    safeDisconnect(ParrySuccessConnection)
+    safeDisconnect(ParrySuccessAllConnection)
+    ParrySuccessConnection = nil
+    ParrySuccessAllConnection = nil
+    ParrySuccessRemote = nil
+    ParrySuccessAllRemote = nil
+end
+
+local function createArray(count)
+    if table.create then
+        return table.create(count)
+    end
+
+    return {}
+end
 
 local function updateInitProgress(stage, details)
     for key in pairs(initProgress) do
@@ -92,12 +361,98 @@ local function resolveParryRemote(report)
 
     assert(remotes, "AutoParry: ReplicatedStorage.Remotes missing")
 
-    report("waiting-remotes", { target = "remote", elapsed = 0 })
+    local candidateDefinitions = {
+        { name = "ParryButtonPress", variant = "modern" },
+        { name = "ParryAttempt", variant = "legacy" },
+    }
+    local candidateNames = clone(PARRY_REMOTE_CANDIDATES)
 
-    local remote = remotes:FindFirstChild("ParryButtonPress")
-    if not remote then
+    report("waiting-remotes", { target = "remote", elapsed = 0, candidates = candidateNames })
+
+    local remote
+    local remoteInfo
+    local baseFire
+
+    local function inspectCandidate(candidate)
+        local okFound, found = pcall(remotes.FindFirstChild, remotes, candidate.name)
+        if not okFound or not found then
+            return nil
+        end
+
+        local isEvent, className = isRemoteEvent(found)
+        if not isEvent then
+            return false, {
+                reason = "parry-remote-unsupported",
+                className = className,
+                remoteName = found.Name,
+                message = string.format(
+                    "AutoParry: parry remote unsupported type (%s)",
+                    className
+                ),
+            }
+        end
+
+        local methodName, fire = findRemoteFire(found)
+        if not methodName or not fire then
+            return false, {
+                reason = "parry-remote-missing-method",
+                className = className,
+                remoteName = found.Name,
+                message = "AutoParry: parry remote missing FireServer/Fire",
+            }
+        end
+
+        local info = {
+            method = methodName,
+            kind = "RemoteEvent",
+            className = className,
+            remoteName = found.Name,
+            variant = candidate.variant,
+        }
+
+        return true, found, fire, info
+    end
+
+    local function findCandidate()
+        local errorDetails
+
+        for _, candidate in ipairs(candidateDefinitions) do
+            local status, found, fire, infoOrError = inspectCandidate(candidate)
+            if status == nil then
+                continue
+            elseif status == true then
+                remote = found
+                baseFire = fire
+                remoteInfo = infoOrError
+                if remoteInfo then
+                    remoteInfo.successRemotes = locateSuccessRemotes(remotes)
+                end
+                return true
+            else
+                errorDetails = infoOrError
+            end
+        end
+
+        if errorDetails then
+            report("error", {
+                stage = "waiting-remotes",
+                target = "remote",
+                reason = errorDetails.reason or "parry-remote-unsupported",
+                className = errorDetails.className,
+                remoteName = errorDetails.remoteName,
+                message = errorDetails.message,
+                candidates = candidateNames,
+            })
+
+            error(errorDetails.message, 0)
+        end
+
+        return false
+    end
+
+    if not findCandidate() then
         local start = os.clock()
-        while not remote do
+        while not findCandidate() do
             local elapsed = os.clock() - start
             if elapsed >= 10 then
                 report("timeout", {
@@ -105,6 +460,7 @@ local function resolveParryRemote(report)
                     target = "remote",
                     elapsed = elapsed,
                     reason = "parry-remote",
+                    candidates = candidateNames,
                 })
                 break
             end
@@ -112,24 +468,228 @@ local function resolveParryRemote(report)
             report("waiting-remotes", {
                 target = "remote",
                 elapsed = elapsed,
+                candidates = candidateNames,
             })
             task.wait()
-            remote = remotes:FindFirstChild("ParryButtonPress")
         end
     end
 
-    assert(remote, "AutoParry: ParryButtonPress remote missing")
-    return remote
+    assert(remote and baseFire and remoteInfo, "AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+
+    return remote, baseFire, remoteInfo
+end
+
+local function capturePlayerState(player)
+    local state = {
+        userId = player and player.UserId or 0,
+    }
+
+    local character = player and player.Character
+    if character then
+        state.character = character
+        local primary = character.PrimaryPart
+        if primary then
+            local okPosition, position = pcall(function()
+                return primary.Position
+            end)
+
+            if okPosition then
+                state.position = position
+            end
+
+            local okVelocity, velocity = pcall(function()
+                return primary.AssemblyLinearVelocity
+            end)
+
+            if okVelocity then
+                state.velocity = velocity
+            end
+
+            local okCFrame, rootCFrame = pcall(function()
+                return primary.CFrame
+            end)
+
+            if okCFrame then
+                state.cframe = rootCFrame
+            end
+        end
+    end
+
+    return state
+end
+
+local function snapshotPlayers()
+    local snapshot = {}
+    local seen = {}
+
+    local function append(player)
+        if not player or seen[player] then
+            return
+        end
+
+        seen[player] = true
+        snapshot[player.Name or tostring(player)] = capturePlayerState(player)
+    end
+
+    if Players and typeOf(Players.GetPlayers) == "function" then
+        local ok, roster = pcall(Players.GetPlayers, Players)
+        if ok and type(roster) == "table" then
+            for _, player in ipairs(roster) do
+                append(player)
+            end
+        end
+    end
+
+    if Players and Players.LocalPlayer then
+        append(Players.LocalPlayer)
+    end
+
+    return snapshot
+end
+
+local function computeBallCFrame(ball, fallbackPosition)
+    if not ball then
+        return CFrame.new(fallbackPosition or Vector3.new())
+    end
+
+    local okExisting, existing = pcall(function()
+        return ball.CFrame
+    end)
+
+    if okExisting and typeOf(existing) == "CFrame" then
+        return existing
+    end
+
+    local position
+    local okPosition, value = pcall(function()
+        return ball.Position
+    end)
+
+    if okPosition and typeOf(value) == "Vector3" then
+        position = value
+    else
+        position = fallbackPosition or Vector3.new()
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball.AssemblyLinearVelocity
+    end)
+
+    if okVelocity and typeOf(velocity) == "Vector3" and velocity.Magnitude > 1e-3 then
+        return CFrame.new(position, position + velocity.Unit)
+    end
+
+    return CFrame.new(position)
+end
+
+local legacyPayloadBuilder = nil
+local randomGenerator = typeOf(Random) == "table" and Random.new() or nil
+
+local function randomInteger(minimum, maximum)
+    if randomGenerator then
+        return randomGenerator:NextInteger(minimum, maximum)
+    end
+
+    return math.random(minimum, maximum)
+end
+
+local function buildLegacyPayload(context)
+    local builder = legacyPayloadBuilder
+    if builder then
+        local payload = builder(context)
+        assert(type(payload) == "table", "legacy payload builder must return an array of arguments")
+        return payload
+    end
+
+    local payload = createArray(5)
+    payload[1] = context.timestamp
+    payload[2] = context.ballCFrame
+    payload[3] = context.playersSnapshot
+    payload[4] = randomInteger(100000, 999999999)
+    payload[5] = randomInteger(100000, 999999999)
+    payload.n = 5
+    return payload
+end
+
+local function createLegacyContext(ball, analysis)
+    local now = os.clock()
+    local rootPosition = analysis and analysis.rootPosition or nil
+    local ballPosition
+    local okPosition, value = pcall(function()
+        return ball and ball.Position
+    end)
+    if okPosition and typeOf(value) == "Vector3" then
+        ballPosition = value
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball and ball.AssemblyLinearVelocity
+    end)
+    if not okVelocity or typeOf(velocity) ~= "Vector3" then
+        velocity = Vector3.new()
+    end
+
+    local tti = analysis and analysis.tti or 0
+
+    return {
+        timestamp = now,
+        ball = ball,
+        ballPosition = ballPosition or Vector3.new(),
+        ballVelocity = velocity,
+        ballCFrame = computeBallCFrame(ball, rootPosition),
+        rootPosition = rootPosition,
+        predictedImpact = now + math.max(tti, 0),
+        ping = analysis and analysis.ping or 0,
+        tti = tti,
+        localPlayer = LocalPlayer,
+        playersSnapshot = snapshotPlayers(),
+    }
+end
+
+local function configureParryRemoteInvoker(remoteInfo)
+    if not ParryRemoteBaseFire then
+        ParryRemoteFire = nil
+        return
+    end
+
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
+    if not variant and ParryRemote then
+        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
+    end
+
+    ParryRemoteVariant = variant
+
+    if variant == "legacy" then
+        ParryRemoteFire = function(ball, analysis)
+            local context = createLegacyContext(ball, analysis)
+            local payload = buildLegacyPayload(context)
+            local length = payload.n or #payload
+            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
+        end
+    else
+        ParryRemoteFire = function()
+            return ParryRemoteBaseFire()
+        end
+    end
 end
 
 local LocalPlayer = nil
 local ParryRemote = nil
+local ParryRemoteFire = nil
+local ParryRemoteVariant = nil
+local ParryRemoteBaseFire = nil
+local ParryRemoteInfo = nil
+local ParryRemoteParentChangedConnection = nil
+local ParryRemoteAncestryConnection = nil
+local ParryRemoteDestroyingConnection = nil
+local ParryRemoteRestartPending = false
 
 local initialization = {
     started = false,
     completed = false,
     error = nil,
     token = 0,
+    destroyed = false,
 }
 
 local function beginInitialization()
@@ -138,6 +698,15 @@ local function beginInitialization()
     initialization.started = true
     initialization.completed = false
     initialization.error = nil
+    initialization.destroyed = false
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    ParryRemoteInfo = nil
+    disconnectSuccessListeners()
+    disconnectParryRemoteMonitors()
+    ParryRemoteRestartPending = false
 
     updateInitProgress("waiting-player", { elapsed = 0 })
 
@@ -152,14 +721,14 @@ local function beginInitialization()
             updateInitProgress(stage, details)
         end
 
-        local ok, player, remoteOrError = pcall(function()
+        local ok, player, remoteOrError, fire, remoteInfo = pcall(function()
             local player = resolveLocalPlayer(report)
             if initialization.token ~= token then
-                return nil, nil
+                return nil, nil, nil, nil
             end
 
-            local remote = resolveParryRemote(report)
-            return player, remote
+            local remote, parryFire, info = resolveParryRemote(report)
+            return player, remote, parryFire, info
         end)
 
         if initialization.token ~= token then
@@ -167,16 +736,80 @@ local function beginInitialization()
         end
 
         if ok then
-            if not player or not remoteOrError then
+            if not player or not remoteOrError or not fire then
                 return
             end
 
             LocalPlayer = player
             ParryRemote = remoteOrError
+            ParryRemoteBaseFire = fire
+            ParryRemoteVariant = remoteInfo and remoteInfo.variant or nil
+            configureParryRemoteInvoker(remoteInfo)
+            monitorParryRemote(remoteOrError, remoteInfo)
+            local successStatus = configureSuccessListeners and configureSuccessListeners(remoteInfo and remoteInfo.successRemotes or nil) or nil
             initialization.completed = true
-            report("ready", { elapsed = os.clock() - initStart })
+            local readyDetails = { elapsed = os.clock() - initStart }
+
+            if remoteInfo then
+                if remoteInfo.kind then
+                    readyDetails.remoteKind = remoteInfo.kind
+                end
+
+                if remoteInfo.method then
+                    readyDetails.remoteMethod = remoteInfo.method
+                end
+
+                if remoteInfo.className then
+                    readyDetails.remoteClass = remoteInfo.className
+                end
+
+                if remoteInfo.remoteName then
+                    readyDetails.remoteName = remoteInfo.remoteName
+                end
+
+                if remoteInfo.variant then
+                    readyDetails.remoteVariant = remoteInfo.variant
+                end
+            end
+
+            if successStatus then
+                readyDetails.successEvents = successStatus
+            end
+
+            if not readyDetails.remoteClass then
+                local okClass, className = pcall(function()
+                    return ParryRemote.ClassName
+                end)
+
+                if okClass then
+                    readyDetails.remoteClass = className
+                end
+            end
+
+            report("ready", readyDetails)
         else
             initialization.error = player
+            local details = { message = player }
+
+            if initProgress.stage == "error" then
+                if initProgress.reason then
+                    details.reason = initProgress.reason
+                end
+
+                if initProgress.target then
+                    details.target = initProgress.target
+                end
+
+                if initProgress.className then
+                    details.className = initProgress.className
+                end
+
+                if initProgress.elapsed then
+                    details.elapsed = initProgress.elapsed
+                end
+            end
+
+            report("error", details)
         end
     end)
 end
@@ -206,10 +839,14 @@ local state = {
     enabled = false,
     connection = nil,
     lastParry = 0,
+    lastSuccess = 0,
+    lastBroadcast = 0,
 }
 
 local stateChanged = Util.Signal.new()
 local parryEvent = Util.Signal.new()
+parrySuccessSignal = Util.Signal.new()
+parryBroadcastSignal = Util.Signal.new()
 local logger = nil
 
 local function waitForReady()
@@ -240,6 +877,184 @@ local function log(...)
     if logger then
         logger(...)
     end
+end
+
+disconnectParryRemoteMonitors = function()
+    safeDisconnect(ParryRemoteParentChangedConnection)
+    safeDisconnect(ParryRemoteAncestryConnection)
+    safeDisconnect(ParryRemoteDestroyingConnection)
+    ParryRemoteParentChangedConnection = nil
+    ParryRemoteAncestryConnection = nil
+    ParryRemoteDestroyingConnection = nil
+end
+
+scheduleParryRemoteRestart = function(reason)
+    if ParryRemoteRestartPending or initialization.destroyed then
+        return
+    end
+
+    ParryRemoteRestartPending = true
+
+    deferTask(function()
+        ParryRemoteRestartPending = false
+        if initialization.destroyed or ParryRemote then
+            return
+        end
+
+        log("AutoParry: restarting initialization after", reason or "parry remote loss")
+        beginInitialization()
+    end)
+end
+
+handleParryRemoteInvalidated = function(reason)
+    if not ParryRemote then
+        return
+    end
+
+    log("AutoParry: parry remote invalidated", reason)
+
+    disconnectParryRemoteMonitors()
+    disconnectSuccessListeners()
+
+    local info = ParryRemoteInfo
+    ParryRemoteInfo = nil
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    initialization.completed = false
+
+    local details = {
+        reason = reason or "parry-remote-invalidated",
+        candidates = clone(PARRY_REMOTE_CANDIDATES),
+    }
+
+    if info then
+        if info.remoteName then
+            details.remoteName = info.remoteName
+        end
+        if info.variant then
+            details.remoteVariant = info.variant
+        end
+        if info.className then
+            details.remoteClass = info.className
+        end
+    end
+
+    updateInitProgress("restarting", details)
+    scheduleParryRemoteRestart(reason)
+end
+
+monitorParryRemote = function(remote, info)
+    disconnectParryRemoteMonitors()
+
+    if not remote then
+        return
+    end
+
+    ParryRemoteRestartPending = false
+
+    local function parent()
+        local okParent, parentInstance = pcall(function()
+            return remote.Parent
+        end)
+
+        return okParent and parentInstance or nil
+    end
+
+    if parent() == nil then
+        handleParryRemoteInvalidated("parry-remote-removed")
+        return
+    end
+
+    ParryRemoteParentChangedConnection = connectPropertyChangedSignal(remote, "Parent", function()
+        if parent() == nil then
+            handleParryRemoteInvalidated("parry-remote-removed")
+        end
+    end)
+
+    ParryRemoteAncestryConnection = connectInstanceEvent(remote, "AncestryChanged", function(_, parentInstance)
+        if parentInstance == nil then
+            handleParryRemoteInvalidated("parry-remote-ancestry")
+        end
+    end)
+
+    ParryRemoteDestroyingConnection = connectInstanceEvent(remote, "Destroying", function()
+        handleParryRemoteInvalidated("parry-remote-destroyed")
+    end)
+
+    if info then
+        ParryRemoteInfo = {
+            remoteName = info.remoteName,
+            variant = info.variant,
+            className = info.className,
+        }
+    else
+        ParryRemoteInfo = {
+            remoteName = remote.Name,
+            variant = ParryRemoteVariant,
+            className = getClassName(remote),
+        }
+    end
+end
+
+configureSuccessListeners = function(successRemotes)
+    disconnectSuccessListeners()
+
+    local status = {
+        ParrySuccess = false,
+        ParrySuccessAll = false,
+    }
+
+    if not successRemotes then
+        return status
+    end
+
+    local localEntry = successRemotes.ParrySuccess
+    if localEntry and localEntry.remote then
+        ParrySuccessRemote = localEntry.remote
+        local connection = connectClientEvent(ParrySuccessRemote, function(...)
+            state.lastSuccess = os.clock()
+            parrySuccessSignal:fire(...)
+            log("AutoParry: observed ParrySuccess event")
+        end)
+
+        if connection then
+            ParrySuccessConnection = connection
+            status.ParrySuccess = true
+            log("AutoParry: listening for ParrySuccess events")
+        else
+            ParrySuccessRemote = nil
+        end
+    end
+
+    local broadcastEntry = successRemotes.ParrySuccessAll
+    if broadcastEntry and broadcastEntry.remote then
+        ParrySuccessAllRemote = broadcastEntry.remote
+        local connection = connectClientEvent(ParrySuccessAllRemote, function(...)
+            state.lastBroadcast = os.clock()
+            parryBroadcastSignal:fire(...)
+            log("AutoParry: observed ParrySuccessAll event")
+        end)
+
+        if connection then
+            ParrySuccessAllConnection = connection
+            status.ParrySuccessAll = true
+            log("AutoParry: listening for ParrySuccessAll events")
+        else
+            ParrySuccessAllRemote = nil
+        end
+    end
+
+    if not status.ParrySuccess then
+        state.lastSuccess = 0
+    end
+
+    if not status.ParrySuccessAll then
+        state.lastBroadcast = 0
+    end
+
+    return status
 end
 
 local function ballsFolder()
@@ -282,14 +1097,22 @@ local function emitState()
     stateChanged:fire(state.enabled)
 end
 
-local function tryParry(ball)
+local function tryParry(ball, analysis)
     local now = os.clock()
     if now - state.lastParry < config.cooldown then
         return false
     end
 
+    if not ParryRemoteFire then
+        if initialization.completed then
+            scheduleParryRemoteRestart("parry-remote-missing")
+        end
+
+        return false
+    end
+
     state.lastParry = now
-    ParryRemote:FireServer()
+    ParryRemoteFire(ball, analysis)
     parryEvent:fire(ball, now)
     log("AutoParry: fired parry for", ball)
     return true
@@ -312,7 +1135,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local toPlayer = (rootPos - ball.Position)
     if toPlayer.Magnitude == 0 then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = toPlayer.Magnitude,
+            velocity = velocity,
+        }
     end
 
     local toward = velocity:Dot(toPlayer.Unit)
@@ -322,7 +1153,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local distanceToPlayer = distance(ball.Position, rootPos)
     if distanceToPlayer <= config.safeRadius then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = distanceToPlayer,
+            velocity = velocity,
+        }
     end
 
     local tti = distanceToPlayer / toward
@@ -332,12 +1171,24 @@ local function evaluateBall(ball, rootPos, ping)
         return nil
     end
 
-    return tti
+    return {
+        ball = ball,
+        rootPosition = rootPos,
+        ping = ping,
+        tti = tti,
+        immediate = false,
+        distance = distanceToPlayer,
+        velocity = velocity,
+    }
 end
 
 local function step()
     local character = LocalPlayer and LocalPlayer.Character
     if not character or not character.PrimaryPart then
+        return
+    end
+
+    if not initialization.completed or not ParryRemoteFire then
         return
     end
 
@@ -351,23 +1202,24 @@ local function step()
     end
 
     local rootPos = character.PrimaryPart.Position
-    local bestBall, bestTti
+    local bestAnalysis
     local ping = currentPing()
 
     for _, ball in ipairs(folder:GetChildren()) do
-        local tti = evaluateBall(ball, rootPos, ping)
-        if tti == 0 then
-            if tryParry(ball) then
-                return
+        local analysis = evaluateBall(ball, rootPos, ping)
+        if analysis then
+            if analysis.tti == 0 then
+                if tryParry(ball, analysis) then
+                    return
+                end
+            elseif not bestAnalysis or analysis.tti < bestAnalysis.tti then
+                bestAnalysis = analysis
             end
-        elseif tti and (not bestTti or tti < bestTti) then
-            bestTti = tti
-            bestBall = ball
         end
     end
 
-    if bestBall then
-        tryParry(bestBall)
+    if bestAnalysis then
+        tryParry(bestAnalysis.ball, bestAnalysis)
     end
 end
 
@@ -479,6 +1331,14 @@ function AutoParry.getLastParryTime()
     return state.lastParry
 end
 
+function AutoParry.getLastParrySuccessTime()
+    return state.lastSuccess
+end
+
+function AutoParry.getLastParryBroadcastTime()
+    return state.lastBroadcast
+end
+
 function AutoParry.onInitStatus(callback)
     assert(typeof(callback) == "function", "AutoParry.onInitStatus expects a function")
 
@@ -504,6 +1364,16 @@ function AutoParry.onParry(callback)
     return parryEvent:connect(callback)
 end
 
+function AutoParry.onParrySuccess(callback)
+    assert(typeof(callback) == "function", "AutoParry.onParrySuccess expects a function")
+    return parrySuccessSignal:connect(callback)
+end
+
+function AutoParry.onParryBroadcast(callback)
+    assert(typeof(callback) == "function", "AutoParry.onParryBroadcast expects a function")
+    return parryBroadcastSignal:connect(callback)
+end
+
 function AutoParry.setLogger(fn)
     if fn ~= nil then
         assert(typeof(fn) == "function", "AutoParry.setLogger expects a function or nil")
@@ -511,21 +1381,55 @@ function AutoParry.setLogger(fn)
     logger = fn
 end
 
+function AutoParry.setLegacyPayloadBuilder(builder)
+    if builder ~= nil then
+        assert(type(builder) == "function", "AutoParry.setLegacyPayloadBuilder expects a function or nil")
+    end
+
+    legacyPayloadBuilder = builder
+
+    if ParryRemoteVariant == "legacy" and ParryRemoteBaseFire then
+        configureParryRemoteInvoker({ variant = ParryRemoteVariant })
+    end
+end
+
 function AutoParry.destroy()
     AutoParry.disable()
+    disconnectSuccessListeners()
+    disconnectParryRemoteMonitors()
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    ParryRemoteInfo = nil
+    ParryRemoteRestartPending = false
+    initialization.token += 1
+    initialization.started = false
+    initialization.completed = false
+    initialization.error = nil
+    initialization.destroyed = true
     stateChanged:destroy()
     parryEvent:destroy()
     initStatus:destroy()
+    parrySuccessSignal:destroy()
+    parryBroadcastSignal:destroy()
 
     stateChanged = Util.Signal.new()
     parryEvent = Util.Signal.new()
     initStatus = Util.Signal.new()
+    parrySuccessSignal = Util.Signal.new()
+    parryBroadcastSignal = Util.Signal.new()
     logger = nil
     state.lastParry = 0
+    state.lastSuccess = 0
+    state.lastBroadcast = 0
     AutoParry.resetConfig()
 
     LocalPlayer = nil
     ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
 
     for key in pairs(initProgress) do
         initProgress[key] = nil

--- a/tests/api/main.spec.lua
+++ b/tests/api/main.spec.lua
@@ -49,6 +49,8 @@ local function createState()
             defaultConfig = deepCopy(defaultConfig),
             config = deepCopy(defaultConfig),
             lastParryTime = 2.5,
+            lastParrySuccessTime = 1.25,
+            lastParryBroadcastTime = 1.75,
             primaryConnection = createConnection(),
             primaryConnectionAssigned = false,
             primaryCallback = nil,
@@ -64,8 +66,12 @@ local function createState()
                 resetConfig = 0,
                 setLogger = {},
                 getLastParryTime = 0,
+                getLastParrySuccessTime = 0,
+                getLastParryBroadcastTime = 0,
                 onStateChanged = 0,
                 onParry = {},
+                onParrySuccess = {},
+                onParryBroadcast = {},
                 destroy = 0,
                 enable = 0,
             },
@@ -236,6 +242,16 @@ function Parry.getLastParryTime()
     return parryState.lastParryTime
 end
 
+function Parry.getLastParrySuccessTime()
+    parryState.calls.getLastParrySuccessTime = parryState.calls.getLastParrySuccessTime + 1
+    return parryState.lastParrySuccessTime
+end
+
+function Parry.getLastParryBroadcastTime()
+    parryState.calls.getLastParryBroadcastTime = parryState.calls.getLastParryBroadcastTime + 1
+    return parryState.lastParryBroadcastTime
+end
+
 function Parry.onStateChanged(callback)
     parryState.calls.onStateChanged = parryState.calls.onStateChanged + 1
     table.insert(parryState.stateChangedCallbacks, callback)
@@ -254,6 +270,16 @@ end
 
 function Parry.onParry(callback)
     table.insert(parryState.calls.onParry, callback)
+    return createConnection()
+end
+
+function Parry.onParrySuccess(callback)
+    table.insert(parryState.calls.onParrySuccess, callback)
+    return createConnection()
+end
+
+function Parry.onParryBroadcast(callback)
+    table.insert(parryState.calls.onParryBroadcast, callback)
     return createConnection()
 end
 

--- a/tests/autoparry/bootstrap.spec.lua
+++ b/tests/autoparry/bootstrap.spec.lua
@@ -27,7 +27,7 @@ return function(t)
 
         local stubPlayer = { Name = "LocalPlayer" }
         scheduler:schedule(3, function()
-            players.LocalPlayer = stubPlayer
+            players:_setLocalPlayer(stubPlayer)
         end)
 
         local autoparry = Harness.loadAutoparry({
@@ -48,6 +48,9 @@ return function(t)
         expect(ready.elapsed):toBeCloseTo(3, 1e-3)
         expect(stages[1].stage):toEqual("waiting-player")
         expect(stages[#stages].stage):toEqual("ready")
+        expect(ready.successEvents ~= nil):toEqual(true)
+        expect(ready.successEvents.ParrySuccess):toEqual(false)
+        expect(ready.successEvents.ParrySuccessAll):toEqual(false)
 
         local snapshot = autoparry.getInitProgress()
         snapshot.stage = "mutated"
@@ -84,6 +87,10 @@ return function(t)
         expect(remotes:FindFirstChild("ParryButtonPress") ~= nil):toBeTruthy()
         expect(scheduler:clock()):toBeCloseTo(4, 1e-3)
         expect(ready.elapsed):toBeCloseTo(4, 1e-3)
+        expect(ready.remoteName):toEqual("ParryButtonPress")
+        expect(ready.remoteVariant):toEqual("modern")
+        expect(ready.successEvents.ParrySuccess):toEqual(false)
+        expect(ready.successEvents.ParrySuccessAll):toEqual(false)
 
         local sawRemoteStage = false
         for _, item in ipairs(stages) do
@@ -175,6 +182,167 @@ return function(t)
         end)
 
         expect(ok):toEqual(false)
-        expect(err):toEqual("AutoParry: ParryButtonPress remote missing")
+        expect(err):toEqual("AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+    end)
+
+    t.test("errors when the parry remote lacks a supported fire method", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        local invalidRemote = { Name = "ParryButtonPress", ClassName = "Folder" }
+        remotes:Add(invalidRemote)
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local progress = waitForStage(scheduler, autoparry, "error", 20)
+
+        expect(progress.stage):toEqual("error")
+        expect(progress.target):toEqual("remote")
+        expect(progress.reason):toEqual("parry-remote-unsupported")
+        expect(progress.className):toEqual("Folder")
+        expect(progress.message):toEqual("AutoParry: parry remote unsupported type (Folder)")
+
+        local ok, err = pcall(function()
+            autoparry.enable()
+        end)
+
+        expect(ok):toEqual(false)
+        expect(err):toEqual("AutoParry: parry remote unsupported type (Folder)")
+    end)
+
+    t.test("listens for parry success events when they exist", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        local parryRemote = Harness.createRemote()
+        remotes:Add(parryRemote)
+        local successRemote = Harness.createRemote({ name = "ParrySuccess" })
+        remotes:Add(successRemote)
+        local successAllRemote = Harness.createRemote({ name = "ParrySuccessAll" })
+        remotes:Add(successAllRemote)
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+
+        expect(ready.successEvents.ParrySuccess):toEqual(true)
+        expect(ready.successEvents.ParrySuccessAll):toEqual(true)
+        expect(autoparry.getLastParrySuccessTime()):toEqual(0)
+        expect(autoparry.getLastParryBroadcastTime()):toEqual(0)
+
+        local successLog = {}
+        local broadcastLog = {}
+
+        local successConnection = autoparry.onParrySuccess(function(...)
+            table.insert(successLog, { time = scheduler:clock(), payload = { ... } })
+        end)
+
+        local broadcastConnection = autoparry.onParryBroadcast(function(...)
+            table.insert(broadcastLog, { time = scheduler:clock(), payload = { ... } })
+        end)
+
+        Harness.fireRemoteClient(successRemote, "local")
+        scheduler:wait()
+
+        expect(#successLog):toEqual(1)
+        expect(autoparry.getLastParrySuccessTime()):toBeCloseTo(successLog[1].time, 1e-3)
+
+        Harness.fireRemoteClient(successAllRemote, "broadcast")
+        scheduler:wait()
+
+        expect(#broadcastLog):toEqual(1)
+        expect(autoparry.getLastParryBroadcastTime()):toBeCloseTo(broadcastLog[1].time, 1e-3)
+        expect(autoparry.getLastParryBroadcastTime()):toBeGreaterThanOrEqual(autoparry.getLastParrySuccessTime())
+
+        if successConnection then
+            successConnection:Disconnect()
+        end
+
+        if broadcastConnection then
+            broadcastConnection:Disconnect()
+        end
+
+        autoparry.destroy()
+    end)
+
+    t.test("falls back to the legacy parry attempt remote when the button press is missing", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        remotes:Add(Harness.createRemote({ name = "ParryAttempt" }))
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+
+        expect(ready.remoteName):toEqual("ParryAttempt")
+        expect(ready.remoteVariant):toEqual("legacy")
+    end)
+
+    t.test("restarts initialization when the parry remote is removed", function(expect)
+        local scheduler = Scheduler.new(1)
+        local services, remotes = Harness.createBaseServices(scheduler, {
+            initialLocalPlayer = { Name = "LocalPlayer" },
+        })
+
+        local parryRemote = Harness.createRemote()
+        remotes:Add(parryRemote)
+
+        local autoparry = Harness.loadAutoparry({
+            scheduler = scheduler,
+            services = services,
+        })
+
+        local stages = {}
+        local connection = autoparry.onInitStatus(function(progress)
+            table.insert(stages, progress)
+        end)
+
+        local ready = waitForStage(scheduler, autoparry, "ready")
+        expect(ready.remoteName):toEqual("ParryButtonPress")
+
+        remotes:Remove(parryRemote.Name)
+        scheduler:wait()
+
+        local sawRestart = false
+        local restartDetails
+        for _, stage in ipairs(stages) do
+            if stage.stage == "restarting" then
+                sawRestart = true
+                restartDetails = stage
+            end
+        end
+
+        expect(sawRestart):toEqual(true)
+        expect(restartDetails ~= nil):toEqual(true)
+        expect(restartDetails.reason):toEqual("parry-remote-removed")
+        expect(restartDetails.remoteName):toEqual("ParryButtonPress")
+
+        scheduler:schedule(2, function()
+            remotes:Add(Harness.createRemote())
+        end)
+
+        local readyAgain = waitForStage(scheduler, autoparry, "ready")
+        expect(readyAgain.remoteName):toEqual("ParryButtonPress")
+        expect(readyAgain.elapsed):toBeGreaterThan(ready.elapsed)
+
+        if connection then
+            connection:Disconnect()
+        end
     end)
 end

--- a/tests/autoparry/destroy.spec.lua
+++ b/tests/autoparry/destroy.spec.lua
@@ -225,6 +225,8 @@ return function(t)
             expect(firstConnection.disconnected):toBeTruthy()
             expect(runServiceProbe.disconnectCount):toEqual(1)
             expect(autoparry1.getLastParryTime()):toEqual(0)
+            expect(autoparry1.getLastParrySuccessTime()):toEqual(0)
+            expect(autoparry1.getLastParryBroadcastTime()):toEqual(0)
             expect(autoparry1.getConfig().cooldown):toEqual(defaults.cooldown)
 
             -- Second session setup via loader
@@ -307,6 +309,8 @@ return function(t)
             expect(secondConnection.disconnected):toBeTruthy()
             expect(runServiceProbe.disconnectCount):toEqual(2)
             expect(autoparry2.getLastParryTime()):toEqual(0)
+            expect(autoparry2.getLastParrySuccessTime()):toEqual(0)
+            expect(autoparry2.getLastParryBroadcastTime()):toEqual(0)
 
             -- Ensure final config reset matches defaults again
             local finalConfig = autoparry2.getConfig()

--- a/tests/autoparry/evaluate_ball.spec.lua
+++ b/tests/autoparry/evaluate_ball.spec.lua
@@ -208,6 +208,13 @@ local function computeExpectedTti(ball, rootPosition, pingSeconds, config)
     return rawTti - (pingSeconds + config.pingOffset)
 end
 
+local function assertAnalysis(expect, analysis, ball, rootPosition)
+    expect(analysis ~= nil):toBeTruthy()
+    expect(analysis.ball).toEqual(ball)
+    expect(analysis.rootPosition).toEqual(rootPosition)
+    return analysis.tti
+end
+
 return function(t)
     t.test("evaluateBall rejects clones that are not BaseParts", function(expect)
         local context = createContext()
@@ -219,8 +226,8 @@ return function(t)
             :withName("NotBasePart")
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -229,8 +236,8 @@ return function(t)
         local builder = BallBuilder.new(context.config)
         local ball = builder:withRealBall(false):build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -242,8 +249,8 @@ return function(t)
             :withVelocity(Vector3.new(0, 0, -slowSpeed))
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -254,8 +261,10 @@ return function(t)
             :withPosition(context.rootPosition)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
         expect(tti):toEqual(0)
+        expect(analysis.immediate):toEqual(true)
         context.autoparry.destroy()
     end)
 
@@ -267,8 +276,8 @@ return function(t)
             :withVelocity(awayVelocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -280,8 +289,8 @@ return function(t)
             :withVelocity(sidewaysVelocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -296,8 +305,10 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
         expect(tti):toEqual(0)
+        expect(analysis.immediate):toEqual(true)
         context.autoparry.destroy()
     end)
 
@@ -311,8 +322,8 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -327,8 +338,8 @@ return function(t)
             :withVelocity(velocity)
             :build(context.ballsFolder)
 
-        local tti = context.evaluateBall(ball, context.rootPosition, 0)
-        expect(tti == nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+        expect(analysis == nil):toBeTruthy()
         context.autoparry.destroy()
     end)
 
@@ -345,8 +356,8 @@ return function(t)
             :build(context.ballsFolder)
 
         local pingSeconds = 0.01
-        local tti = context.evaluateBall(ball, context.rootPosition, pingSeconds)
-        expect(tti ~= nil):toBeTruthy()
+        local analysis = context.evaluateBall(ball, context.rootPosition, pingSeconds)
+        local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
 
         local expected = computeExpectedTti(ball, context.rootPosition, pingSeconds, context.config)
         expect(tti):toBeCloseTo(expected, 1e-3)
@@ -371,8 +382,8 @@ return function(t)
             )
 
             local ball = builder:withVelocity(velocity):build(context.ballsFolder)
-            local tti = context.evaluateBall(ball, context.rootPosition, 0)
-            expect(tti == nil):toBeTruthy()
+            local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+            expect(analysis == nil):toBeTruthy()
         end
 
         context.autoparry.destroy()
@@ -394,8 +405,8 @@ return function(t)
             )
 
             local ball = builder:withVelocity(velocity):build(context.ballsFolder)
-            local tti = context.evaluateBall(ball, context.rootPosition, 0)
-            expect(tti ~= nil):toBeTruthy()
+            local analysis = context.evaluateBall(ball, context.rootPosition, 0)
+            local tti = assertAnalysis(expect, analysis, ball, context.rootPosition)
 
             local expected = computeExpectedTti(ball, context.rootPosition, 0, context.config)
             expect(tti):toBeCloseTo(expected, 1e-3)

--- a/tests/autoparry/harness.lua
+++ b/tests/autoparry/harness.lua
@@ -55,7 +55,28 @@ local function createContainer(scheduler, name)
 
     function container:Add(child)
         children[child.Name] = child
-        child.Parent = container
+        if type(child._mockSetParent) == "function" then
+            child:_mockSetParent(container)
+        else
+            child.Parent = container
+        end
+        return child
+    end
+
+    function container:Remove(childName)
+        local child = children[childName]
+        if not child then
+            return nil
+        end
+
+        children[childName] = nil
+
+        if type(child._mockSetParent) == "function" then
+            child:_mockSetParent(nil)
+        else
+            child.Parent = nil
+        end
+
         return child
     end
 
@@ -90,14 +111,151 @@ end
 
 Harness.createContainer = createContainer
 
-function Harness.createRemote()
-    local remote = { Name = "ParryButtonPress" }
+local function createSignal()
+    local handlers = {}
+    local nextId = 0
 
-    function remote:FireServer(...)
-        self.lastPayload = { ... }
+    local signal = {}
+
+    function signal:Connect(callback)
+        nextId += 1
+        handlers[nextId] = callback
+
+        local connection = { _id = nextId }
+
+        function connection:Disconnect()
+            handlers[connection._id] = nil
+        end
+
+        connection.disconnect = connection.Disconnect
+
+        return connection
+    end
+
+    signal.connect = signal.Connect
+
+    function signal:Fire(...)
+        for _, callback in pairs(handlers) do
+            callback(...)
+        end
+    end
+
+    signal.fire = signal.Fire
+
+    return signal
+end
+
+function Harness.createRemote(options)
+    options = options or {}
+
+    local kind = options.kind or "RemoteEvent"
+    local name = options.name or "ParryButtonPress"
+    local className = options.className
+
+    local remote = { Name = name, Parent = nil }
+    local propertySignals = {}
+
+    local function ensurePropertySignal(propertyName)
+        local signal = propertySignals[propertyName]
+        if not signal then
+            signal = createSignal()
+            propertySignals[propertyName] = signal
+        end
+
+        return signal
+    end
+
+    function remote:GetPropertyChangedSignal(propertyName)
+        return ensurePropertySignal(propertyName)
+    end
+
+    local ancestrySignal = createSignal()
+    local destroyingSignal = createSignal()
+    remote.AncestryChanged = ancestrySignal
+    remote.Destroying = destroyingSignal
+
+    function remote:_mockSetParent(newParent)
+        if remote.Parent == newParent then
+            return
+        end
+
+        remote.Parent = newParent
+
+        local parentSignal = propertySignals.Parent
+        if parentSignal then
+            parentSignal:Fire()
+        end
+
+        ancestrySignal:Fire(remote, newParent)
+    end
+
+    function remote:_mockDestroy()
+        remote:_mockSetParent(nil)
+        destroyingSignal:Fire(remote)
+    end
+
+    local function assign(methodName, impl)
+        remote[methodName] = impl
+        remote._parryMethod = methodName
+    end
+
+    if kind == "RemoteEvent" then
+        remote.ClassName = className or "RemoteEvent"
+
+        assign("FireServer", function(self, ...)
+            self.lastPayload = { ... }
+        end)
+
+        local signal = createSignal()
+        remote.OnClientEvent = signal
+        remote._mockFireClient = function(_, ...)
+            signal:Fire(...)
+        end
+        remote._mockFireAllClients = remote._mockFireClient
+    elseif kind == "BindableEvent" then
+        remote.ClassName = className or "BindableEvent"
+
+        assign("Fire", function(self, ...)
+            self.lastPayload = { ... }
+        end)
+    elseif kind == "RemoteFunction" then
+        remote.ClassName = className or "RemoteFunction"
+
+        assign("InvokeServer", function(self, ...)
+            self.lastPayload = { ... }
+        end)
+    elseif kind == "BindableFunction" then
+        remote.ClassName = className or "BindableFunction"
+
+        assign("Invoke", function(self, ...)
+            self.lastPayload = { ... }
+        end)
+    else
+        error(string.format("Unsupported remote kind: %s", tostring(kind)))
     end
 
     return remote
+end
+
+function Harness.fireRemoteClient(remote, ...)
+    if not remote then
+        return
+    end
+
+    local signal = remote.OnClientEvent
+    if not signal then
+        return
+    end
+
+    local ok, fire = pcall(function()
+        return signal.Fire or signal.fire
+    end)
+
+    if ok and fire then
+        fire(signal, ...)
+    elseif type(signal) == "function" then
+        signal(...)
+    end
 end
 
 function Harness.createRunService()
@@ -291,10 +449,45 @@ end
 
 function Harness.createBaseServices(scheduler, options)
     options = options or {}
-    local players = options.players or { LocalPlayer = options.initialLocalPlayer }
+    local players = options.players or {}
 
-    if players.LocalPlayer == nil and options.initialLocalPlayer ~= nil then
-        players.LocalPlayer = options.initialLocalPlayer
+    local rosterList = {}
+    local rosterSet = {}
+
+    local function addPlayer(player)
+        if player and not rosterSet[player] then
+            rosterSet[player] = true
+            table.insert(rosterList, player)
+        end
+    end
+
+    function players:GetPlayers()
+        local result = {}
+        for index, player in ipairs(rosterList) do
+            result[index] = player
+        end
+        return result
+    end
+
+    function players:_setLocalPlayer(player)
+        rawset(self, "LocalPlayer", player)
+        addPlayer(player)
+    end
+
+    function players:_addPlayer(player)
+        addPlayer(player)
+    end
+
+    if options.initialLocalPlayer ~= nil then
+        players:_setLocalPlayer(options.initialLocalPlayer)
+    elseif players.LocalPlayer ~= nil then
+        addPlayer(players.LocalPlayer)
+    end
+
+    if options.playersList then
+        for _, player in ipairs(options.playersList) do
+            addPlayer(player)
+        end
     end
 
     local replicated = options.replicated or createContainer(scheduler, "ReplicatedStorage")

--- a/tests/autoparry/ping.spec.lua
+++ b/tests/autoparry/ping.spec.lua
@@ -87,13 +87,15 @@ return function(t)
         for index, scenario in ipairs(scenarios) do
             local pingSeconds = currentPing()
             local ball = makeBall(15, 45)
-            local tti = evaluateBall(ball, rootPosition, pingSeconds)
+            local analysis = evaluateBall(ball, rootPosition, pingSeconds)
 
-            expect(tti ~= nil):toBeTruthy()
+            expect(analysis ~= nil):toBeTruthy()
 
+            local tti = analysis.tti
             local expectedAdjustment = pingSeconds + config.pingOffset
             local expectedTti = baseTti - expectedAdjustment
             expect(tti):toBeCloseTo(expectedTti, 1e-3)
+            expect(analysis.ping):toEqual(pingSeconds)
 
             table.insert(observations, {
                 sequence = index,

--- a/tests/fixtures/AutoParrySourceMap.lua
+++ b/tests/fixtures/AutoParrySourceMap.lua
@@ -13,12 +13,281 @@ local Stats = game:GetService("Stats")
 local Require = rawget(_G, "ARequire")
 local Util = Require("src/shared/util.lua")
 
+local luauTypeof = rawget(_G, "typeof")
+local arrayUnpack = table.unpack or unpack
+
+local function typeOf(value)
+    if luauTypeof then
+        local ok, result = pcall(luauTypeof, value)
+        if ok then
+            return result
+        end
+    end
+
+    return type(value)
+end
+
+local function isCallable(value)
+    return typeOf(value) == "function"
+end
+
+local function safeDisconnect(connection)
+    if not connection then
+        return
+    end
+
+    local okMethod, disconnectMethod = pcall(function()
+        return connection.Disconnect or connection.disconnect
+    end)
+
+    if okMethod and isCallable(disconnectMethod) then
+        pcall(disconnectMethod, connection)
+    end
+end
+
+local function connectClientEvent(remote, handler)
+    if not remote or not handler then
+        return nil
+    end
+
+    local okEvent, event = pcall(function()
+        return remote.OnClientEvent
+    end)
+    if not okEvent or event == nil then
+        return nil
+    end
+
+    local okConnect, connection = pcall(function()
+        return event:Connect(handler)
+    end)
+    if okConnect and connection then
+        return connection
+    end
+
+    local okMethod, connectMethod = pcall(function()
+        return event.Connect or event.connect
+    end)
+    if okMethod and isCallable(connectMethod) then
+        local success, result = pcall(connectMethod, event, handler)
+        if success then
+            return result
+        end
+    end
+
+    return nil
+end
+
+local function connectSignal(signal, handler)
+    if not signal or not handler then
+        return nil
+    end
+
+    local okMethod, connectMethod = pcall(function()
+        return signal.Connect or signal.connect
+    end)
+
+    if okMethod and isCallable(connectMethod) then
+        local success, connection = pcall(connectMethod, signal, handler)
+        if success then
+            return connection
+        end
+    end
+
+    return nil
+end
+
+local function connectInstanceEvent(instance, eventName, handler)
+    if not instance or not handler then
+        return nil
+    end
+
+    local okEvent, event = pcall(function()
+        return instance[eventName]
+    end)
+
+    if not okEvent or event == nil then
+        return nil
+    end
+
+    return connectSignal(event, handler)
+end
+
+local function connectPropertyChangedSignal(instance, propertyName, handler)
+    if not instance or not handler then
+        return nil
+    end
+
+    local okGetter, getSignal = pcall(function()
+        return instance.GetPropertyChangedSignal
+    end)
+
+    if not okGetter or not isCallable(getSignal) then
+        return nil
+    end
+
+    local okSignal, signal = pcall(getSignal, instance, propertyName)
+    if not okSignal or signal == nil then
+        return nil
+    end
+
+    return connectSignal(signal, handler)
+end
+
+local function getClassName(instance)
+    if instance == nil then
+        return "nil"
+    end
+
+    local okClass, className = pcall(function()
+        return instance.ClassName
+    end)
+    if okClass and type(className) == "string" then
+        return className
+    end
+
+    local okType, typeName = pcall(typeOf, instance)
+    if okType and type(typeName) == "string" then
+        return typeName
+    end
+
+    return type(instance)
+end
+
+local function isRemoteEvent(remote)
+    if remote == nil then
+        return false, "nil"
+    end
+
+    local okIsA, result = pcall(function()
+        local method = remote.IsA
+        if not isCallable(method) then
+            return nil
+        end
+        return method(remote, "RemoteEvent")
+    end)
+
+    if okIsA and result == true then
+        return true, getClassName(remote)
+    end
+
+    local className = getClassName(remote)
+    if className == "RemoteEvent" then
+        return true, className
+    end
+
+    return false, className
+end
+
+local function locateSuccessRemotes(remotes)
+    local success = {}
+    if not remotes or typeOf(remotes.FindFirstChild) ~= "function" then
+        return success
+    end
+
+    local definitions = {
+        { key = "ParrySuccess", name = "ParrySuccess" },
+        { key = "ParrySuccessAll", name = "ParrySuccessAll" },
+    }
+
+    for _, definition in ipairs(definitions) do
+        local okRemote, remote = pcall(remotes.FindFirstChild, remotes, definition.name)
+        if okRemote and remote then
+            local isEvent = isRemoteEvent(remote)
+            if isEvent then
+                success[definition.key] = { remote = remote, name = definition.name }
+            end
+        end
+    end
+
+    return success
+end
+
+local function createRemoteFireWrapper(remote, methodName)
+    return function(...)
+        local current = remote[methodName]
+        if not isCallable(current) then
+            error(
+                string.format(
+                    "AutoParry: parry remote missing %s",
+                    methodName
+                ),
+                0
+            )
+        end
+
+        return current(remote, ...)
+    end
+end
+
+local function findRemoteFire(remote)
+    local okServer, fireServer = pcall(function()
+        return remote.FireServer
+    end)
+    if okServer and isCallable(fireServer) then
+        return "FireServer", createRemoteFireWrapper(remote, "FireServer")
+    end
+
+    local okFire, fire = pcall(function()
+        return remote.Fire
+    end)
+    if okFire and isCallable(fire) then
+        return "Fire", createRemoteFireWrapper(remote, "Fire")
+    end
+
+    return nil, nil
+end
+
 local function clone(tbl)
     return Util.deepCopy(tbl)
 end
 
+local function deferTask(callback)
+    local okDefer, deferImpl = pcall(function()
+        return task.defer
+    end)
+
+    if okDefer and isCallable(deferImpl) then
+        return deferImpl(callback)
+    end
+
+    return task.spawn(callback)
+end
+
 local initStatus = Util.Signal.new()
 local initProgress = { stage = "waiting-player" }
+
+local state
+local parrySuccessSignal
+local parryBroadcastSignal
+local ParrySuccessConnection = nil
+local ParrySuccessAllConnection = nil
+local ParrySuccessRemote = nil
+local ParrySuccessAllRemote = nil
+local configureSuccessListeners
+local disconnectSuccessListeners
+local monitorParryRemote
+local handleParryRemoteInvalidated
+local disconnectParryRemoteMonitors
+local scheduleParryRemoteRestart
+
+local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress", "ParryAttempt" }
+
+local function disconnectSuccessListeners()
+    safeDisconnect(ParrySuccessConnection)
+    safeDisconnect(ParrySuccessAllConnection)
+    ParrySuccessConnection = nil
+    ParrySuccessAllConnection = nil
+    ParrySuccessRemote = nil
+    ParrySuccessAllRemote = nil
+end
+
+local function createArray(count)
+    if table.create then
+        return table.create(count)
+    end
+
+    return {}
+end
 
 local function updateInitProgress(stage, details)
     for key in pairs(initProgress) do
@@ -95,12 +364,98 @@ local function resolveParryRemote(report)
 
     assert(remotes, "AutoParry: ReplicatedStorage.Remotes missing")
 
-    report("waiting-remotes", { target = "remote", elapsed = 0 })
+    local candidateDefinitions = {
+        { name = "ParryButtonPress", variant = "modern" },
+        { name = "ParryAttempt", variant = "legacy" },
+    }
+    local candidateNames = clone(PARRY_REMOTE_CANDIDATES)
 
-    local remote = remotes:FindFirstChild("ParryButtonPress")
-    if not remote then
+    report("waiting-remotes", { target = "remote", elapsed = 0, candidates = candidateNames })
+
+    local remote
+    local remoteInfo
+    local baseFire
+
+    local function inspectCandidate(candidate)
+        local okFound, found = pcall(remotes.FindFirstChild, remotes, candidate.name)
+        if not okFound or not found then
+            return nil
+        end
+
+        local isEvent, className = isRemoteEvent(found)
+        if not isEvent then
+            return false, {
+                reason = "parry-remote-unsupported",
+                className = className,
+                remoteName = found.Name,
+                message = string.format(
+                    "AutoParry: parry remote unsupported type (%s)",
+                    className
+                ),
+            }
+        end
+
+        local methodName, fire = findRemoteFire(found)
+        if not methodName or not fire then
+            return false, {
+                reason = "parry-remote-missing-method",
+                className = className,
+                remoteName = found.Name,
+                message = "AutoParry: parry remote missing FireServer/Fire",
+            }
+        end
+
+        local info = {
+            method = methodName,
+            kind = "RemoteEvent",
+            className = className,
+            remoteName = found.Name,
+            variant = candidate.variant,
+        }
+
+        return true, found, fire, info
+    end
+
+    local function findCandidate()
+        local errorDetails
+
+        for _, candidate in ipairs(candidateDefinitions) do
+            local status, found, fire, infoOrError = inspectCandidate(candidate)
+            if status == nil then
+                continue
+            elseif status == true then
+                remote = found
+                baseFire = fire
+                remoteInfo = infoOrError
+                if remoteInfo then
+                    remoteInfo.successRemotes = locateSuccessRemotes(remotes)
+                end
+                return true
+            else
+                errorDetails = infoOrError
+            end
+        end
+
+        if errorDetails then
+            report("error", {
+                stage = "waiting-remotes",
+                target = "remote",
+                reason = errorDetails.reason or "parry-remote-unsupported",
+                className = errorDetails.className,
+                remoteName = errorDetails.remoteName,
+                message = errorDetails.message,
+                candidates = candidateNames,
+            })
+
+            error(errorDetails.message, 0)
+        end
+
+        return false
+    end
+
+    if not findCandidate() then
         local start = os.clock()
-        while not remote do
+        while not findCandidate() do
             local elapsed = os.clock() - start
             if elapsed >= 10 then
                 report("timeout", {
@@ -108,6 +463,7 @@ local function resolveParryRemote(report)
                     target = "remote",
                     elapsed = elapsed,
                     reason = "parry-remote",
+                    candidates = candidateNames,
                 })
                 break
             end
@@ -115,24 +471,228 @@ local function resolveParryRemote(report)
             report("waiting-remotes", {
                 target = "remote",
                 elapsed = elapsed,
+                candidates = candidateNames,
             })
             task.wait()
-            remote = remotes:FindFirstChild("ParryButtonPress")
         end
     end
 
-    assert(remote, "AutoParry: ParryButtonPress remote missing")
-    return remote
+    assert(remote and baseFire and remoteInfo, "AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+
+    return remote, baseFire, remoteInfo
+end
+
+local function capturePlayerState(player)
+    local state = {
+        userId = player and player.UserId or 0,
+    }
+
+    local character = player and player.Character
+    if character then
+        state.character = character
+        local primary = character.PrimaryPart
+        if primary then
+            local okPosition, position = pcall(function()
+                return primary.Position
+            end)
+
+            if okPosition then
+                state.position = position
+            end
+
+            local okVelocity, velocity = pcall(function()
+                return primary.AssemblyLinearVelocity
+            end)
+
+            if okVelocity then
+                state.velocity = velocity
+            end
+
+            local okCFrame, rootCFrame = pcall(function()
+                return primary.CFrame
+            end)
+
+            if okCFrame then
+                state.cframe = rootCFrame
+            end
+        end
+    end
+
+    return state
+end
+
+local function snapshotPlayers()
+    local snapshot = {}
+    local seen = {}
+
+    local function append(player)
+        if not player or seen[player] then
+            return
+        end
+
+        seen[player] = true
+        snapshot[player.Name or tostring(player)] = capturePlayerState(player)
+    end
+
+    if Players and typeOf(Players.GetPlayers) == "function" then
+        local ok, roster = pcall(Players.GetPlayers, Players)
+        if ok and type(roster) == "table" then
+            for _, player in ipairs(roster) do
+                append(player)
+            end
+        end
+    end
+
+    if Players and Players.LocalPlayer then
+        append(Players.LocalPlayer)
+    end
+
+    return snapshot
+end
+
+local function computeBallCFrame(ball, fallbackPosition)
+    if not ball then
+        return CFrame.new(fallbackPosition or Vector3.new())
+    end
+
+    local okExisting, existing = pcall(function()
+        return ball.CFrame
+    end)
+
+    if okExisting and typeOf(existing) == "CFrame" then
+        return existing
+    end
+
+    local position
+    local okPosition, value = pcall(function()
+        return ball.Position
+    end)
+
+    if okPosition and typeOf(value) == "Vector3" then
+        position = value
+    else
+        position = fallbackPosition or Vector3.new()
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball.AssemblyLinearVelocity
+    end)
+
+    if okVelocity and typeOf(velocity) == "Vector3" and velocity.Magnitude > 1e-3 then
+        return CFrame.new(position, position + velocity.Unit)
+    end
+
+    return CFrame.new(position)
+end
+
+local legacyPayloadBuilder = nil
+local randomGenerator = typeOf(Random) == "table" and Random.new() or nil
+
+local function randomInteger(minimum, maximum)
+    if randomGenerator then
+        return randomGenerator:NextInteger(minimum, maximum)
+    end
+
+    return math.random(minimum, maximum)
+end
+
+local function buildLegacyPayload(context)
+    local builder = legacyPayloadBuilder
+    if builder then
+        local payload = builder(context)
+        assert(type(payload) == "table", "legacy payload builder must return an array of arguments")
+        return payload
+    end
+
+    local payload = createArray(5)
+    payload[1] = context.timestamp
+    payload[2] = context.ballCFrame
+    payload[3] = context.playersSnapshot
+    payload[4] = randomInteger(100000, 999999999)
+    payload[5] = randomInteger(100000, 999999999)
+    payload.n = 5
+    return payload
+end
+
+local function createLegacyContext(ball, analysis)
+    local now = os.clock()
+    local rootPosition = analysis and analysis.rootPosition or nil
+    local ballPosition
+    local okPosition, value = pcall(function()
+        return ball and ball.Position
+    end)
+    if okPosition and typeOf(value) == "Vector3" then
+        ballPosition = value
+    end
+
+    local okVelocity, velocity = pcall(function()
+        return ball and ball.AssemblyLinearVelocity
+    end)
+    if not okVelocity or typeOf(velocity) ~= "Vector3" then
+        velocity = Vector3.new()
+    end
+
+    local tti = analysis and analysis.tti or 0
+
+    return {
+        timestamp = now,
+        ball = ball,
+        ballPosition = ballPosition or Vector3.new(),
+        ballVelocity = velocity,
+        ballCFrame = computeBallCFrame(ball, rootPosition),
+        rootPosition = rootPosition,
+        predictedImpact = now + math.max(tti, 0),
+        ping = analysis and analysis.ping or 0,
+        tti = tti,
+        localPlayer = LocalPlayer,
+        playersSnapshot = snapshotPlayers(),
+    }
+end
+
+local function configureParryRemoteInvoker(remoteInfo)
+    if not ParryRemoteBaseFire then
+        ParryRemoteFire = nil
+        return
+    end
+
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
+    if not variant and ParryRemote then
+        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
+    end
+
+    ParryRemoteVariant = variant
+
+    if variant == "legacy" then
+        ParryRemoteFire = function(ball, analysis)
+            local context = createLegacyContext(ball, analysis)
+            local payload = buildLegacyPayload(context)
+            local length = payload.n or #payload
+            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
+        end
+    else
+        ParryRemoteFire = function()
+            return ParryRemoteBaseFire()
+        end
+    end
 end
 
 local LocalPlayer = nil
 local ParryRemote = nil
+local ParryRemoteFire = nil
+local ParryRemoteVariant = nil
+local ParryRemoteBaseFire = nil
+local ParryRemoteInfo = nil
+local ParryRemoteParentChangedConnection = nil
+local ParryRemoteAncestryConnection = nil
+local ParryRemoteDestroyingConnection = nil
+local ParryRemoteRestartPending = false
 
 local initialization = {
     started = false,
     completed = false,
     error = nil,
     token = 0,
+    destroyed = false,
 }
 
 local function beginInitialization()
@@ -141,6 +701,15 @@ local function beginInitialization()
     initialization.started = true
     initialization.completed = false
     initialization.error = nil
+    initialization.destroyed = false
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    ParryRemoteInfo = nil
+    disconnectSuccessListeners()
+    disconnectParryRemoteMonitors()
+    ParryRemoteRestartPending = false
 
     updateInitProgress("waiting-player", { elapsed = 0 })
 
@@ -155,14 +724,14 @@ local function beginInitialization()
             updateInitProgress(stage, details)
         end
 
-        local ok, player, remoteOrError = pcall(function()
+        local ok, player, remoteOrError, fire, remoteInfo = pcall(function()
             local player = resolveLocalPlayer(report)
             if initialization.token ~= token then
-                return nil, nil
+                return nil, nil, nil, nil
             end
 
-            local remote = resolveParryRemote(report)
-            return player, remote
+            local remote, parryFire, info = resolveParryRemote(report)
+            return player, remote, parryFire, info
         end)
 
         if initialization.token ~= token then
@@ -170,16 +739,80 @@ local function beginInitialization()
         end
 
         if ok then
-            if not player or not remoteOrError then
+            if not player or not remoteOrError or not fire then
                 return
             end
 
             LocalPlayer = player
             ParryRemote = remoteOrError
+            ParryRemoteBaseFire = fire
+            ParryRemoteVariant = remoteInfo and remoteInfo.variant or nil
+            configureParryRemoteInvoker(remoteInfo)
+            monitorParryRemote(remoteOrError, remoteInfo)
+            local successStatus = configureSuccessListeners and configureSuccessListeners(remoteInfo and remoteInfo.successRemotes or nil) or nil
             initialization.completed = true
-            report("ready", { elapsed = os.clock() - initStart })
+            local readyDetails = { elapsed = os.clock() - initStart }
+
+            if remoteInfo then
+                if remoteInfo.kind then
+                    readyDetails.remoteKind = remoteInfo.kind
+                end
+
+                if remoteInfo.method then
+                    readyDetails.remoteMethod = remoteInfo.method
+                end
+
+                if remoteInfo.className then
+                    readyDetails.remoteClass = remoteInfo.className
+                end
+
+                if remoteInfo.remoteName then
+                    readyDetails.remoteName = remoteInfo.remoteName
+                end
+
+                if remoteInfo.variant then
+                    readyDetails.remoteVariant = remoteInfo.variant
+                end
+            end
+
+            if successStatus then
+                readyDetails.successEvents = successStatus
+            end
+
+            if not readyDetails.remoteClass then
+                local okClass, className = pcall(function()
+                    return ParryRemote.ClassName
+                end)
+
+                if okClass then
+                    readyDetails.remoteClass = className
+                end
+            end
+
+            report("ready", readyDetails)
         else
             initialization.error = player
+            local details = { message = player }
+
+            if initProgress.stage == "error" then
+                if initProgress.reason then
+                    details.reason = initProgress.reason
+                end
+
+                if initProgress.target then
+                    details.target = initProgress.target
+                end
+
+                if initProgress.className then
+                    details.className = initProgress.className
+                end
+
+                if initProgress.elapsed then
+                    details.elapsed = initProgress.elapsed
+                end
+            end
+
+            report("error", details)
         end
     end)
 end
@@ -209,10 +842,14 @@ local state = {
     enabled = false,
     connection = nil,
     lastParry = 0,
+    lastSuccess = 0,
+    lastBroadcast = 0,
 }
 
 local stateChanged = Util.Signal.new()
 local parryEvent = Util.Signal.new()
+parrySuccessSignal = Util.Signal.new()
+parryBroadcastSignal = Util.Signal.new()
 local logger = nil
 
 local function waitForReady()
@@ -243,6 +880,184 @@ local function log(...)
     if logger then
         logger(...)
     end
+end
+
+disconnectParryRemoteMonitors = function()
+    safeDisconnect(ParryRemoteParentChangedConnection)
+    safeDisconnect(ParryRemoteAncestryConnection)
+    safeDisconnect(ParryRemoteDestroyingConnection)
+    ParryRemoteParentChangedConnection = nil
+    ParryRemoteAncestryConnection = nil
+    ParryRemoteDestroyingConnection = nil
+end
+
+scheduleParryRemoteRestart = function(reason)
+    if ParryRemoteRestartPending or initialization.destroyed then
+        return
+    end
+
+    ParryRemoteRestartPending = true
+
+    deferTask(function()
+        ParryRemoteRestartPending = false
+        if initialization.destroyed or ParryRemote then
+            return
+        end
+
+        log("AutoParry: restarting initialization after", reason or "parry remote loss")
+        beginInitialization()
+    end)
+end
+
+handleParryRemoteInvalidated = function(reason)
+    if not ParryRemote then
+        return
+    end
+
+    log("AutoParry: parry remote invalidated", reason)
+
+    disconnectParryRemoteMonitors()
+    disconnectSuccessListeners()
+
+    local info = ParryRemoteInfo
+    ParryRemoteInfo = nil
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    initialization.completed = false
+
+    local details = {
+        reason = reason or "parry-remote-invalidated",
+        candidates = clone(PARRY_REMOTE_CANDIDATES),
+    }
+
+    if info then
+        if info.remoteName then
+            details.remoteName = info.remoteName
+        end
+        if info.variant then
+            details.remoteVariant = info.variant
+        end
+        if info.className then
+            details.remoteClass = info.className
+        end
+    end
+
+    updateInitProgress("restarting", details)
+    scheduleParryRemoteRestart(reason)
+end
+
+monitorParryRemote = function(remote, info)
+    disconnectParryRemoteMonitors()
+
+    if not remote then
+        return
+    end
+
+    ParryRemoteRestartPending = false
+
+    local function parent()
+        local okParent, parentInstance = pcall(function()
+            return remote.Parent
+        end)
+
+        return okParent and parentInstance or nil
+    end
+
+    if parent() == nil then
+        handleParryRemoteInvalidated("parry-remote-removed")
+        return
+    end
+
+    ParryRemoteParentChangedConnection = connectPropertyChangedSignal(remote, "Parent", function()
+        if parent() == nil then
+            handleParryRemoteInvalidated("parry-remote-removed")
+        end
+    end)
+
+    ParryRemoteAncestryConnection = connectInstanceEvent(remote, "AncestryChanged", function(_, parentInstance)
+        if parentInstance == nil then
+            handleParryRemoteInvalidated("parry-remote-ancestry")
+        end
+    end)
+
+    ParryRemoteDestroyingConnection = connectInstanceEvent(remote, "Destroying", function()
+        handleParryRemoteInvalidated("parry-remote-destroyed")
+    end)
+
+    if info then
+        ParryRemoteInfo = {
+            remoteName = info.remoteName,
+            variant = info.variant,
+            className = info.className,
+        }
+    else
+        ParryRemoteInfo = {
+            remoteName = remote.Name,
+            variant = ParryRemoteVariant,
+            className = getClassName(remote),
+        }
+    end
+end
+
+configureSuccessListeners = function(successRemotes)
+    disconnectSuccessListeners()
+
+    local status = {
+        ParrySuccess = false,
+        ParrySuccessAll = false,
+    }
+
+    if not successRemotes then
+        return status
+    end
+
+    local localEntry = successRemotes.ParrySuccess
+    if localEntry and localEntry.remote then
+        ParrySuccessRemote = localEntry.remote
+        local connection = connectClientEvent(ParrySuccessRemote, function(...)
+            state.lastSuccess = os.clock()
+            parrySuccessSignal:fire(...)
+            log("AutoParry: observed ParrySuccess event")
+        end)
+
+        if connection then
+            ParrySuccessConnection = connection
+            status.ParrySuccess = true
+            log("AutoParry: listening for ParrySuccess events")
+        else
+            ParrySuccessRemote = nil
+        end
+    end
+
+    local broadcastEntry = successRemotes.ParrySuccessAll
+    if broadcastEntry and broadcastEntry.remote then
+        ParrySuccessAllRemote = broadcastEntry.remote
+        local connection = connectClientEvent(ParrySuccessAllRemote, function(...)
+            state.lastBroadcast = os.clock()
+            parryBroadcastSignal:fire(...)
+            log("AutoParry: observed ParrySuccessAll event")
+        end)
+
+        if connection then
+            ParrySuccessAllConnection = connection
+            status.ParrySuccessAll = true
+            log("AutoParry: listening for ParrySuccessAll events")
+        else
+            ParrySuccessAllRemote = nil
+        end
+    end
+
+    if not status.ParrySuccess then
+        state.lastSuccess = 0
+    end
+
+    if not status.ParrySuccessAll then
+        state.lastBroadcast = 0
+    end
+
+    return status
 end
 
 local function ballsFolder()
@@ -285,14 +1100,22 @@ local function emitState()
     stateChanged:fire(state.enabled)
 end
 
-local function tryParry(ball)
+local function tryParry(ball, analysis)
     local now = os.clock()
     if now - state.lastParry < config.cooldown then
         return false
     end
 
+    if not ParryRemoteFire then
+        if initialization.completed then
+            scheduleParryRemoteRestart("parry-remote-missing")
+        end
+
+        return false
+    end
+
     state.lastParry = now
-    ParryRemote:FireServer()
+    ParryRemoteFire(ball, analysis)
     parryEvent:fire(ball, now)
     log("AutoParry: fired parry for", ball)
     return true
@@ -315,7 +1138,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local toPlayer = (rootPos - ball.Position)
     if toPlayer.Magnitude == 0 then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = toPlayer.Magnitude,
+            velocity = velocity,
+        }
     end
 
     local toward = velocity:Dot(toPlayer.Unit)
@@ -325,7 +1156,15 @@ local function evaluateBall(ball, rootPos, ping)
 
     local distanceToPlayer = distance(ball.Position, rootPos)
     if distanceToPlayer <= config.safeRadius then
-        return 0
+        return {
+            ball = ball,
+            rootPosition = rootPos,
+            ping = ping,
+            tti = 0,
+            immediate = true,
+            distance = distanceToPlayer,
+            velocity = velocity,
+        }
     end
 
     local tti = distanceToPlayer / toward
@@ -335,12 +1174,24 @@ local function evaluateBall(ball, rootPos, ping)
         return nil
     end
 
-    return tti
+    return {
+        ball = ball,
+        rootPosition = rootPos,
+        ping = ping,
+        tti = tti,
+        immediate = false,
+        distance = distanceToPlayer,
+        velocity = velocity,
+    }
 end
 
 local function step()
     local character = LocalPlayer and LocalPlayer.Character
     if not character or not character.PrimaryPart then
+        return
+    end
+
+    if not initialization.completed or not ParryRemoteFire then
         return
     end
 
@@ -354,23 +1205,24 @@ local function step()
     end
 
     local rootPos = character.PrimaryPart.Position
-    local bestBall, bestTti
+    local bestAnalysis
     local ping = currentPing()
 
     for _, ball in ipairs(folder:GetChildren()) do
-        local tti = evaluateBall(ball, rootPos, ping)
-        if tti == 0 then
-            if tryParry(ball) then
-                return
+        local analysis = evaluateBall(ball, rootPos, ping)
+        if analysis then
+            if analysis.tti == 0 then
+                if tryParry(ball, analysis) then
+                    return
+                end
+            elseif not bestAnalysis or analysis.tti < bestAnalysis.tti then
+                bestAnalysis = analysis
             end
-        elseif tti and (not bestTti or tti < bestTti) then
-            bestTti = tti
-            bestBall = ball
         end
     end
 
-    if bestBall then
-        tryParry(bestBall)
+    if bestAnalysis then
+        tryParry(bestAnalysis.ball, bestAnalysis)
     end
 end
 
@@ -482,6 +1334,14 @@ function AutoParry.getLastParryTime()
     return state.lastParry
 end
 
+function AutoParry.getLastParrySuccessTime()
+    return state.lastSuccess
+end
+
+function AutoParry.getLastParryBroadcastTime()
+    return state.lastBroadcast
+end
+
 function AutoParry.onInitStatus(callback)
     assert(typeof(callback) == "function", "AutoParry.onInitStatus expects a function")
 
@@ -507,6 +1367,16 @@ function AutoParry.onParry(callback)
     return parryEvent:connect(callback)
 end
 
+function AutoParry.onParrySuccess(callback)
+    assert(typeof(callback) == "function", "AutoParry.onParrySuccess expects a function")
+    return parrySuccessSignal:connect(callback)
+end
+
+function AutoParry.onParryBroadcast(callback)
+    assert(typeof(callback) == "function", "AutoParry.onParryBroadcast expects a function")
+    return parryBroadcastSignal:connect(callback)
+end
+
 function AutoParry.setLogger(fn)
     if fn ~= nil then
         assert(typeof(fn) == "function", "AutoParry.setLogger expects a function or nil")
@@ -514,21 +1384,55 @@ function AutoParry.setLogger(fn)
     logger = fn
 end
 
+function AutoParry.setLegacyPayloadBuilder(builder)
+    if builder ~= nil then
+        assert(type(builder) == "function", "AutoParry.setLegacyPayloadBuilder expects a function or nil")
+    end
+
+    legacyPayloadBuilder = builder
+
+    if ParryRemoteVariant == "legacy" and ParryRemoteBaseFire then
+        configureParryRemoteInvoker({ variant = ParryRemoteVariant })
+    end
+end
+
 function AutoParry.destroy()
     AutoParry.disable()
+    disconnectSuccessListeners()
+    disconnectParryRemoteMonitors()
+    ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
+    ParryRemoteInfo = nil
+    ParryRemoteRestartPending = false
+    initialization.token += 1
+    initialization.started = false
+    initialization.completed = false
+    initialization.error = nil
+    initialization.destroyed = true
     stateChanged:destroy()
     parryEvent:destroy()
     initStatus:destroy()
+    parrySuccessSignal:destroy()
+    parryBroadcastSignal:destroy()
 
     stateChanged = Util.Signal.new()
     parryEvent = Util.Signal.new()
     initStatus = Util.Signal.new()
+    parrySuccessSignal = Util.Signal.new()
+    parryBroadcastSignal = Util.Signal.new()
     logger = nil
     state.lastParry = 0
+    state.lastSuccess = 0
+    state.lastBroadcast = 0
     AutoParry.resetConfig()
 
     LocalPlayer = nil
     ParryRemote = nil
+    ParryRemoteFire = nil
+    ParryRemoteBaseFire = nil
+    ParryRemoteVariant = nil
 
     for key in pairs(initProgress) do
         initProgress[key] = nil


### PR DESCRIPTION
## Summary
- monitor and restart initialization when the parry remote disappears so parry attempts pause instead of erroring
- harden the parry loop around missing remotes while expanding the harness and specs to swap remotes and cover the recovery flow
- update the autoparry source map fixture to mirror the new core implementation

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68e51b61146c832a976037acd1a50385