### PR TITLE
Refine verification dashboard with in-app branding

### DIFF
--- a/src/ui/verification_dashboard.lua
+++ b/src/ui/verification_dashboard.lua
@@ -1,0 +1,1244 @@
+-- mikkel32/AutoParry : src/ui/verification_dashboard.lua
+-- Futuristic verification dashboard used by the loading overlay. Renders a
+-- neon timeline that visualises the orchestrator's verification stages with
+-- animated status icons, tooltips, and action hooks.
+
+local TweenService = game:GetService("TweenService")
+
+local Require = rawget(_G, "ARequire")
+local Util = Require("src/shared/util.lua")
+
+local VerificationDashboard = {}
+VerificationDashboard.__index = VerificationDashboard
+
+local STATUS_PRIORITY = {
+    pending = 0,
+    active = 1,
+    ok = 2,
+    warning = 3,
+    failed = 4,
+}
+
+local STEP_DEFINITIONS = {
+    {
+        id = "player",
+        title = "Player Sync",
+        description = "Locking on to your avatar and character rig.",
+        tooltip = "AutoParry waits for the LocalPlayer and character to spawn before continuing.",
+    },
+    {
+        id = "remotes",
+        title = "Remotes",
+        description = "Scanning Blade Ball network remotes.",
+        tooltip = "Detects the parry remote and required folders inside ReplicatedStorage.Remotes.",
+    },
+    {
+        id = "success",
+        title = "Success Events",
+        description = "Tracking parry success broadcasts.",
+        tooltip = "Watches ParrySuccess events so AutoParry can react instantly to successes.",
+    },
+    {
+        id = "balls",
+        title = "Ball Telemetry",
+        description = "Locating live balls for prediction.",
+        tooltip = "Ensures the configured balls folder exists so projectiles can be analysed.",
+    },
+}
+
+local DEFAULT_THEME = {
+    accentColor = Color3.fromRGB(0, 210, 255),
+    backgroundTransparency = 1,
+    cardColor = Color3.fromRGB(22, 28, 48),
+    cardTransparency = 0.08,
+    cardStrokeColor = Color3.fromRGB(0, 150, 255),
+    cardStrokeTransparency = 0.45,
+    connectorColor = Color3.fromRGB(0, 170, 255),
+    connectorTransparency = 0.55,
+    pendingColor = Color3.fromRGB(95, 112, 140),
+    activeColor = Color3.fromRGB(0, 195, 255),
+    okColor = Color3.fromRGB(0, 230, 180),
+    warningColor = Color3.fromRGB(255, 196, 0),
+    failedColor = Color3.fromRGB(255, 70, 95),
+    tooltipBackground = Color3.fromRGB(12, 16, 32),
+    tooltipTransparency = 0.05,
+    tooltipTextColor = Color3.fromRGB(215, 230, 255),
+    titleFont = Enum.Font.GothamBlack,
+    titleTextSize = 20,
+    subtitleFont = Enum.Font.Gotham,
+    subtitleTextSize = 16,
+    stepTitleFont = Enum.Font.GothamSemibold,
+    stepTitleTextSize = 17,
+    stepStatusFont = Enum.Font.Gotham,
+    stepStatusTextSize = 14,
+    tooltipFont = Enum.Font.Gotham,
+    tooltipTextSize = 14,
+    actionFont = Enum.Font.GothamBold,
+    actionTextSize = 16,
+    actionHeight = 36,
+    actionCorner = UDim.new(0, 10),
+    actionPrimaryColor = Color3.fromRGB(0, 210, 255),
+    actionPrimaryTextColor = Color3.fromRGB(10, 12, 20),
+    actionSecondaryColor = Color3.fromRGB(30, 40, 60),
+    actionSecondaryTextColor = Color3.fromRGB(215, 230, 255),
+    logo = {
+        width = 230,
+        text = "AutoParry",
+        font = Enum.Font.GothamBlack,
+        textSize = 28,
+        textGradient = ColorSequence.new({
+            ColorSequenceKeypoint.new(0, Color3.fromRGB(0, 210, 255)),
+            ColorSequenceKeypoint.new(1, Color3.fromRGB(0, 236, 173)),
+        }),
+        textGradientRotation = 15,
+        textStrokeColor = Color3.fromRGB(10, 12, 24),
+        textStrokeTransparency = 0.6,
+        primaryColor = Color3.fromRGB(235, 245, 255),
+        tagline = "Neural shield online",
+        taglineFont = Enum.Font.Gotham,
+        taglineTextSize = 15,
+        taglineColor = Color3.fromRGB(188, 206, 255),
+        taglineTransparency = 0,
+        backgroundColor = Color3.fromRGB(16, 20, 36),
+        backgroundTransparency = 0.08,
+        strokeColor = Color3.fromRGB(0, 180, 255),
+        strokeTransparency = 0.35,
+        gradient = ColorSequence.new({
+            ColorSequenceKeypoint.new(0, Color3.fromRGB(12, 18, 30)),
+            ColorSequenceKeypoint.new(1, Color3.fromRGB(0, 195, 255)),
+        }),
+        gradientTransparency = NumberSequence.new({
+            NumberSequenceKeypoint.new(0, 0.55),
+            NumberSequenceKeypoint.new(0.4, 0.35),
+            NumberSequenceKeypoint.new(1, 0.15),
+        }),
+        gradientRotation = 120,
+        glyphImage = "rbxassetid://12148062841",
+        glyphColor = Color3.fromRGB(0, 230, 200),
+        glyphTransparency = 0.2,
+    },
+    iconography = {
+        pending = "rbxassetid://6031071050",
+        active = "rbxassetid://6031075929",
+        check = "rbxassetid://6031068421",
+        warning = "rbxassetid://6031071051",
+        error = "rbxassetid://6031094678",
+    },
+}
+
+local STATUS_STYLE = {
+    pending = function(theme)
+        return {
+            icon = theme.iconography.pending,
+            color = theme.pendingColor,
+            label = "Pending",
+            strokeTransparency = 0.7,
+        }
+    end,
+    active = function(theme)
+        return {
+            icon = theme.iconography.active or theme.iconography.pending,
+            color = theme.activeColor,
+            label = "Scanning…",
+            strokeTransparency = 0.35,
+        }
+    end,
+    ok = function(theme)
+        return {
+            icon = theme.iconography.check,
+            color = theme.okColor,
+            label = "Ready",
+            strokeTransparency = 0.2,
+        }
+    end,
+    warning = function(theme)
+        return {
+            icon = theme.iconography.warning,
+            color = theme.warningColor,
+            label = "Warning",
+            strokeTransparency = 0.25,
+        }
+    end,
+    failed = function(theme)
+        return {
+            icon = theme.iconography.error,
+            color = theme.failedColor,
+            label = "Failed",
+            strokeTransparency = 0.15,
+        }
+    end,
+}
+
+local function mergeTable(base, overrides)
+    if typeof(overrides) ~= "table" then
+        return base
+    end
+
+    local merged = Util.deepCopy(base)
+    for key, value in pairs(overrides) do
+        if typeof(value) == "table" and typeof(merged[key]) == "table" then
+            merged[key] = mergeTable(merged[key], value)
+        else
+            merged[key] = value
+        end
+    end
+    return merged
+end
+
+local function createLogoBadge(parent, theme)
+    local config = mergeTable(DEFAULT_THEME.logo, theme.logo or {})
+
+    local badge = Instance.new("Frame")
+    badge.Name = "LogoBadge"
+    badge.AnchorPoint = Vector2.new(0, 0.5)
+    badge.Position = UDim2.new(0, 0, 0.5, 0)
+    badge.Size = UDim2.new(1, 0, 1, -8)
+    badge.BackgroundColor3 = config.backgroundColor or theme.cardColor
+    badge.BackgroundTransparency = config.backgroundTransparency or 0.1
+    badge.BorderSizePixel = 0
+    badge.ClipsDescendants = true
+    badge.Parent = parent
+
+    local corner = Instance.new("UICorner")
+    corner.CornerRadius = UDim.new(0, 14)
+    corner.Parent = badge
+
+    local stroke = Instance.new("UIStroke")
+    stroke.Thickness = 1.6
+    stroke.Transparency = config.strokeTransparency or 0.35
+    stroke.Color = config.strokeColor or theme.accentColor
+    stroke.Parent = badge
+
+    local gradient = Instance.new("UIGradient")
+    gradient.Color = config.gradient or DEFAULT_THEME.logo.gradient
+    gradient.Transparency = config.gradientTransparency or DEFAULT_THEME.logo.gradientTransparency
+    gradient.Rotation = config.gradientRotation or DEFAULT_THEME.logo.gradientRotation or 120
+    gradient.Parent = badge
+
+    local glyph = Instance.new("ImageLabel")
+    glyph.Name = "Glyph"
+    glyph.AnchorPoint = Vector2.new(0, 0.5)
+    glyph.Position = UDim2.new(0, 14, 0.5, 0)
+    glyph.Size = UDim2.new(0, 34, 0, 34)
+    glyph.BackgroundTransparency = 1
+    glyph.Image = config.glyphImage or (theme.iconography and theme.iconography.hologram) or ""
+    glyph.ImageColor3 = config.glyphColor or theme.accentColor
+    glyph.ImageTransparency = config.glyphTransparency or 0.2
+    glyph.Parent = badge
+
+    local wordmark = Instance.new("TextLabel")
+    wordmark.Name = "Wordmark"
+    wordmark.AnchorPoint = Vector2.new(0, 0.5)
+    wordmark.Position = UDim2.new(0, 58, 0.5, -10)
+    wordmark.Size = UDim2.new(1, -70, 0, 30)
+    wordmark.BackgroundTransparency = 1
+    wordmark.Font = config.font or DEFAULT_THEME.logo.font
+    wordmark.TextSize = config.textSize or DEFAULT_THEME.logo.textSize
+    wordmark.Text = string.upper(config.text or DEFAULT_THEME.logo.text)
+    wordmark.TextColor3 = config.primaryColor or Color3.fromRGB(235, 245, 255)
+    wordmark.TextXAlignment = Enum.TextXAlignment.Left
+    wordmark.TextStrokeColor3 = config.textStrokeColor or Color3.fromRGB(10, 12, 24)
+    wordmark.TextStrokeTransparency = config.textStrokeTransparency or 0.6
+    wordmark.Parent = badge
+
+    local wordmarkGradient = Instance.new("UIGradient")
+    wordmarkGradient.Name = "WordmarkGradient"
+    wordmarkGradient.Color = config.textGradient or DEFAULT_THEME.logo.textGradient
+    wordmarkGradient.Rotation = config.textGradientRotation or DEFAULT_THEME.logo.textGradientRotation or 0
+    wordmarkGradient.Parent = wordmark
+
+    local tagline = Instance.new("TextLabel")
+    tagline.Name = "Tagline"
+    tagline.AnchorPoint = Vector2.new(0, 0.5)
+    tagline.Position = UDim2.new(0, 58, 0.5, 16)
+    tagline.Size = UDim2.new(1, -70, 0, 22)
+    tagline.BackgroundTransparency = 1
+    tagline.Font = config.taglineFont or DEFAULT_THEME.logo.taglineFont
+    tagline.TextSize = config.taglineTextSize or DEFAULT_THEME.logo.taglineTextSize
+    tagline.TextColor3 = config.taglineColor or DEFAULT_THEME.logo.taglineColor
+    tagline.Text = config.tagline or DEFAULT_THEME.logo.tagline
+    tagline.TextTransparency = config.taglineTransparency or 0
+    tagline.TextXAlignment = Enum.TextXAlignment.Left
+    tagline.Parent = badge
+
+    return {
+        frame = badge,
+        stroke = stroke,
+        gradient = gradient,
+        glyph = glyph,
+        wordmark = wordmark,
+        wordmarkGradient = wordmarkGradient,
+        tagline = tagline,
+    }
+end
+
+local function createTooltip(parent, theme, text)
+    local tooltip = Instance.new("TextLabel")
+    tooltip.Name = "Tooltip"
+    tooltip.AnchorPoint = Vector2.new(0.5, 1)
+    tooltip.Position = UDim2.new(0.5, 0, 0, -6)
+    tooltip.BackgroundColor3 = theme.tooltipBackground
+    tooltip.BackgroundTransparency = theme.tooltipTransparency
+    tooltip.TextColor3 = theme.tooltipTextColor
+    tooltip.Text = text or ""
+    tooltip.TextWrapped = true
+    tooltip.Visible = false
+    tooltip.Size = UDim2.new(0.9, 0, 0, 48)
+    tooltip.Font = theme.tooltipFont
+    tooltip.TextSize = theme.tooltipTextSize
+    tooltip.ZIndex = 4
+    tooltip.Parent = parent
+
+    local corner = Instance.new("UICorner")
+    corner.CornerRadius = UDim.new(0, 8)
+    corner.Parent = tooltip
+
+    local stroke = Instance.new("UIStroke")
+    stroke.Thickness = 1
+    stroke.Transparency = 0.4
+    stroke.Color = theme.accentColor
+    stroke.Parent = tooltip
+
+    return tooltip
+end
+
+local function createStep(parent, definition, theme)
+    local frame = Instance.new("Frame")
+    frame.Name = definition.id
+    frame.Size = UDim2.new(1, 0, 0, 72)
+    frame.BackgroundColor3 = theme.cardColor
+    frame.BackgroundTransparency = theme.cardTransparency
+    frame.BorderSizePixel = 0
+    frame.Parent = parent
+    frame.ClipsDescendants = true
+    frame.ZIndex = 2
+
+    local corner = Instance.new("UICorner")
+    corner.CornerRadius = UDim.new(0, 12)
+    corner.Parent = frame
+
+    local stroke = Instance.new("UIStroke")
+    stroke.Thickness = 1.5
+    stroke.Color = theme.cardStrokeColor
+    stroke.Transparency = theme.cardStrokeTransparency
+    stroke.Parent = frame
+
+    local gradient = Instance.new("UIGradient")
+    gradient.Color = ColorSequence.new({
+        ColorSequenceKeypoint.new(0, theme.cardColor),
+        ColorSequenceKeypoint.new(1, theme.cardColor:Lerp(theme.accentColor, 0.08)),
+    })
+    gradient.Transparency = NumberSequence.new({
+        NumberSequenceKeypoint.new(0, theme.cardTransparency + 0.05),
+        NumberSequenceKeypoint.new(1, theme.cardTransparency + 0.15),
+    })
+    gradient.Rotation = 120
+    gradient.Parent = frame
+
+    local icon = Instance.new("ImageLabel")
+    icon.Name = "StatusIcon"
+    icon.AnchorPoint = Vector2.new(0.5, 0.5)
+    icon.Position = UDim2.new(0, 34, 0.5, 0)
+    icon.Size = UDim2.new(0, 36, 0, 36)
+    icon.BackgroundTransparency = 1
+    icon.Image = theme.iconography.pending
+    icon.ImageTransparency = 0.25
+    icon.ImageColor3 = theme.pendingColor
+    icon.ZIndex = 3
+    icon.Parent = frame
+
+    local iconGlow = Instance.new("UIStroke")
+    iconGlow.Thickness = 2
+    iconGlow.Transparency = 0.4
+    iconGlow.Color = theme.pendingColor
+    iconGlow.Parent = icon
+
+    local title = Instance.new("TextLabel")
+    title.Name = "Title"
+    title.AnchorPoint = Vector2.new(0, 0)
+    title.Position = UDim2.new(0, 66, 0, 10)
+    title.Size = UDim2.new(1, -90, 0, 24)
+    title.BackgroundTransparency = 1
+    title.Font = theme.stepTitleFont
+    title.TextSize = theme.stepTitleTextSize
+    title.TextColor3 = Color3.fromRGB(235, 240, 255)
+    title.TextXAlignment = Enum.TextXAlignment.Left
+    title.Text = definition.title
+    title.Parent = frame
+
+    local status = Instance.new("TextLabel")
+    status.Name = "Status"
+    status.AnchorPoint = Vector2.new(0, 0)
+    status.Position = UDim2.new(0, 66, 0, 34)
+    status.Size = UDim2.new(1, -90, 0, 24)
+    status.BackgroundTransparency = 1
+    status.Font = theme.stepStatusFont
+    status.TextSize = theme.stepStatusTextSize
+    status.TextColor3 = Color3.fromRGB(180, 194, 235)
+    status.TextXAlignment = Enum.TextXAlignment.Left
+    status.Text = definition.description
+    status.Parent = frame
+
+    local connector = Instance.new("Frame")
+    connector.Name = "Connector"
+    connector.AnchorPoint = Vector2.new(0.5, 0)
+    connector.Position = UDim2.new(0, 34, 1, -4)
+    connector.Size = UDim2.new(0, 4, 0, 24)
+    connector.BackgroundColor3 = theme.connectorColor
+    connector.BackgroundTransparency = theme.connectorTransparency
+    connector.BorderSizePixel = 0
+    connector.ZIndex = 1
+    connector.Parent = frame
+
+    local tooltip = createTooltip(frame, theme, definition.tooltip)
+
+    local hoverArea = Instance.new("TextButton")
+    hoverArea.Name = "Hover"
+    hoverArea.BackgroundTransparency = 1
+    hoverArea.Text = ""
+    hoverArea.Size = UDim2.new(1, 0, 1, 0)
+    hoverArea.AutoButtonColor = false
+    hoverArea.ZIndex = 5
+    hoverArea.Parent = frame
+
+    local step = {
+        id = definition.id,
+        frame = frame,
+        icon = icon,
+        iconGlow = iconGlow,
+        title = title,
+        status = status,
+        connector = connector,
+        tooltip = tooltip,
+        hoverArea = hoverArea,
+        state = "pending",
+        priority = STATUS_PRIORITY.pending,
+        iconTween = nil,
+    }
+
+    hoverArea.MouseEnter:Connect(function()
+        tooltip.Visible = true
+        tooltip.TextTransparency = 1
+        TweenService:Create(
+            tooltip,
+            TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+            { TextTransparency = 0.05, BackgroundTransparency = theme.tooltipTransparency }
+        ):Play()
+    end)
+
+    local function hideTooltip()
+        if tooltip.Visible then
+            TweenService:Create(
+                tooltip,
+                TweenInfo.new(0.2, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+                { TextTransparency = 1, BackgroundTransparency = 1 }
+            ):Play()
+            task.delay(0.22, function()
+                tooltip.Visible = false
+            end)
+        end
+    end
+
+    hoverArea.MouseLeave:Connect(hideTooltip)
+    hoverArea.MouseButton1Down:Connect(hideTooltip)
+
+    return step
+end
+
+local function styleActionButton(button, theme, action)
+    local isSecondary = action.variant == "secondary" or action.kind == "cancel"
+    button.AutoButtonColor = true
+    button.BackgroundColor3 = isSecondary and theme.actionSecondaryColor or theme.actionPrimaryColor
+    button.TextColor3 = isSecondary and theme.actionSecondaryTextColor or theme.actionPrimaryTextColor
+    button.Font = theme.actionFont
+    button.TextSize = theme.actionTextSize
+    button.Size = UDim2.new(0, action.width or 140, 0, theme.actionHeight)
+
+    local corner = Instance.new("UICorner")
+    corner.CornerRadius = theme.actionCorner
+    corner.Parent = button
+
+    local stroke = Instance.new("UIStroke")
+    stroke.Thickness = 1.5
+    stroke.Transparency = 0.35
+    stroke.Color = theme.accentColor
+    stroke.Parent = button
+end
+
+function VerificationDashboard.new(options)
+    options = options or {}
+    local theme = mergeTable(DEFAULT_THEME, options.theme or {})
+
+    local parent = options.parent
+    assert(parent, "VerificationDashboard.new requires a parent frame")
+
+    local root = Instance.new("Frame")
+    root.Name = options.name or "VerificationDashboard"
+    root.BackgroundTransparency = theme.backgroundTransparency
+    root.BackgroundColor3 = Color3.new(0, 0, 0)
+    root.Size = UDim2.new(1, 0, 1, 0)
+    root.BorderSizePixel = 0
+    root.Parent = parent
+
+    local padding = Instance.new("UIPadding")
+    padding.PaddingTop = UDim.new(0, 12)
+    padding.PaddingBottom = UDim.new(0, 12)
+    padding.PaddingLeft = UDim.new(0, 12)
+    padding.PaddingRight = UDim.new(0, 12)
+    padding.Parent = root
+
+    local header = Instance.new("Frame")
+    header.Name = "Header"
+    header.BackgroundTransparency = 1
+    header.Size = UDim2.new(1, 0, 0, 82)
+    header.Parent = root
+
+    local headerLayout = Instance.new("UIListLayout")
+    headerLayout.FillDirection = Enum.FillDirection.Horizontal
+    headerLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    headerLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+    headerLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    headerLayout.Padding = UDim.new(0, 18)
+    headerLayout.Parent = header
+
+    local logoContainer = Instance.new("Frame")
+    logoContainer.Name = "LogoContainer"
+    logoContainer.BackgroundTransparency = 1
+    logoContainer.Size = UDim2.new(0, 230, 1, 0)
+    logoContainer.Parent = header
+
+    local logoElements = createLogoBadge(logoContainer, theme)
+
+    local textContainer = Instance.new("Frame")
+    textContainer.Name = "HeaderText"
+    textContainer.BackgroundTransparency = 1
+    textContainer.Size = UDim2.new(1, -230, 1, 0)
+    textContainer.Parent = header
+
+    local textLayout = Instance.new("UIListLayout")
+    textLayout.FillDirection = Enum.FillDirection.Vertical
+    textLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    textLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+    textLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    textLayout.Padding = UDim.new(0, 4)
+    textLayout.Parent = textContainer
+
+    local title = Instance.new("TextLabel")
+    title.Name = "Heading"
+    title.BackgroundTransparency = 1
+    title.Size = UDim2.new(1, 0, 0, 30)
+    title.Font = theme.titleFont
+    title.TextSize = theme.titleTextSize
+    title.TextColor3 = Color3.fromRGB(235, 245, 255)
+    title.TextXAlignment = Enum.TextXAlignment.Left
+    title.Text = "Verification Timeline"
+    title.LayoutOrder = 1
+    title.Parent = textContainer
+
+    local subtitle = Instance.new("TextLabel")
+    subtitle.Name = "Subtitle"
+    subtitle.BackgroundTransparency = 1
+    subtitle.Size = UDim2.new(1, 0, 0, 24)
+    subtitle.Font = theme.subtitleFont
+    subtitle.TextSize = theme.subtitleTextSize
+    subtitle.TextColor3 = Color3.fromRGB(170, 184, 220)
+    subtitle.TextXAlignment = Enum.TextXAlignment.Left
+    subtitle.Text = "Preparing AutoParry systems…"
+    subtitle.LayoutOrder = 2
+    subtitle.Parent = textContainer
+
+    local progressTrack = Instance.new("Frame")
+    progressTrack.Name = "ProgressTrack"
+    progressTrack.AnchorPoint = Vector2.new(0, 0)
+    progressTrack.Position = UDim2.new(0, 0, 0, 96)
+    progressTrack.Size = UDim2.new(1, 0, 0, 6)
+    progressTrack.BackgroundColor3 = Color3.fromRGB(26, 32, 52)
+    progressTrack.BackgroundTransparency = 0.15
+    progressTrack.BorderSizePixel = 0
+    progressTrack.Parent = root
+
+    local trackCorner = Instance.new("UICorner")
+    trackCorner.CornerRadius = UDim.new(0, 6)
+    trackCorner.Parent = progressTrack
+
+    local progressFill = Instance.new("Frame")
+    progressFill.Name = "Fill"
+    progressFill.Size = UDim2.new(0, 0, 1, 0)
+    progressFill.BackgroundColor3 = theme.accentColor
+    progressFill.BorderSizePixel = 0
+    progressFill.Parent = progressTrack
+
+    local progressCorner = Instance.new("UICorner")
+    progressCorner.CornerRadius = UDim.new(0, 6)
+    progressCorner.Parent = progressFill
+
+    local glow = Instance.new("UIGradient")
+    glow.Color = ColorSequence.new({
+        ColorSequenceKeypoint.new(0, theme.accentColor),
+        ColorSequenceKeypoint.new(1, theme.accentColor:lerp(Color3.new(1, 1, 1), 0.25)),
+    })
+    glow.Transparency = NumberSequence.new({
+        NumberSequenceKeypoint.new(0, 0.1),
+        NumberSequenceKeypoint.new(1, 0.4),
+    })
+    glow.Parent = progressFill
+
+    local listFrame = Instance.new("Frame")
+    listFrame.Name = "Steps"
+    listFrame.AnchorPoint = Vector2.new(0, 0)
+    listFrame.Position = UDim2.new(0, 0, 0, 128)
+    listFrame.Size = UDim2.new(1, 0, 1, -(theme.actionHeight + 208))
+    listFrame.BackgroundTransparency = 1
+    listFrame.Parent = root
+
+    local listLayout = Instance.new("UIListLayout")
+    listLayout.FillDirection = Enum.FillDirection.Vertical
+    listLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    listLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    listLayout.Padding = UDim.new(0, 10)
+    listLayout.Parent = listFrame
+
+    local steps = {}
+    for index, definition in ipairs(STEP_DEFINITIONS) do
+        local step = createStep(listFrame, definition, theme)
+        step.frame.LayoutOrder = index
+        if index == #STEP_DEFINITIONS then
+            step.connector.Visible = false
+        end
+        steps[definition.id] = step
+    end
+
+    local actionsFrame = Instance.new("Frame")
+    actionsFrame.Name = "Actions"
+    actionsFrame.AnchorPoint = Vector2.new(0, 1)
+    actionsFrame.Position = UDim2.new(0, 0, 1, 0)
+    actionsFrame.Size = UDim2.new(1, 0, 0, theme.actionHeight + 12)
+    actionsFrame.BackgroundTransparency = 1
+    actionsFrame.Visible = false
+    actionsFrame.Parent = root
+
+    local actionsLayout = Instance.new("UIListLayout")
+    actionsLayout.FillDirection = Enum.FillDirection.Horizontal
+    actionsLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
+    actionsLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    actionsLayout.Padding = UDim.new(0, 12)
+    actionsLayout.Parent = actionsFrame
+
+    local self = setmetatable({
+        _theme = theme,
+        _root = root,
+        _header = header,
+        _title = title,
+        _subtitle = subtitle,
+        _progressFill = progressFill,
+        _progressTween = nil,
+        _stepsFrame = listFrame,
+        _steps = steps,
+        _stepStates = {},
+        _actionsFrame = actionsFrame,
+        _actionsLayout = actionsLayout,
+        _actionButtons = {},
+        _actionConnections = {},
+        _actions = nil,
+        _headerText = textContainer,
+        _logoContainer = logoContainer,
+        _logoFrame = logoElements and logoElements.frame,
+        _logoStroke = logoElements and logoElements.stroke,
+        _logoGradient = logoElements and logoElements.gradient,
+        _logoGlyph = logoElements and logoElements.glyph,
+        _logoWordmark = logoElements and logoElements.wordmark,
+        _logoWordmarkGradient = logoElements and logoElements.wordmarkGradient,
+        _logoTagline = logoElements and logoElements.tagline,
+        _logoShimmerTween = nil,
+        _destroyed = false,
+    }, VerificationDashboard)
+
+    for _, definition in ipairs(STEP_DEFINITIONS) do
+        self._stepStates[definition.id] = { status = "pending", priority = STATUS_PRIORITY.pending }
+    end
+
+    self:_applyLogoTheme()
+    self:_startLogoShimmer()
+    self:setProgress(0)
+
+    return self
+end
+
+function VerificationDashboard:_stopLogoShimmer()
+    if self._logoShimmerTween then
+        self._logoShimmerTween:Cancel()
+        self._logoShimmerTween = nil
+    end
+end
+
+function VerificationDashboard:_startLogoShimmer()
+    if self._destroyed then
+        return
+    end
+
+    if not self._logoGradient then
+        return
+    end
+
+    self:_stopLogoShimmer()
+
+    local tween = TweenService:Create(
+        self._logoGradient,
+        TweenInfo.new(4.8, Enum.EasingStyle.Sine, Enum.EasingDirection.InOut, -1, true),
+        { Offset = Vector2.new(0.35, 0) }
+    )
+    self._logoGradient.Offset = Vector2.new(-0.35, 0)
+    tween:Play()
+    self._logoShimmerTween = tween
+end
+
+function VerificationDashboard:_applyLogoTheme()
+    if self._destroyed then
+        return
+    end
+
+    local theme = self._theme or DEFAULT_THEME
+    local config = mergeTable(DEFAULT_THEME.logo, theme.logo or {})
+    local logoWidth = config.width or DEFAULT_THEME.logo.width or 230
+
+    if self._logoContainer then
+        self._logoContainer.Size = UDim2.new(0, logoWidth, 1, 0)
+    end
+
+    if self._headerText then
+        self._headerText.Size = UDim2.new(1, -logoWidth, 1, 0)
+    end
+
+    if self._logoFrame then
+        self._logoFrame.BackgroundColor3 = config.backgroundColor or theme.cardColor
+        self._logoFrame.BackgroundTransparency = config.backgroundTransparency or 0.1
+    end
+
+    if self._logoStroke then
+        self._logoStroke.Color = config.strokeColor or theme.accentColor
+        self._logoStroke.Transparency = config.strokeTransparency or 0.35
+    end
+
+    if self._logoGradient then
+        self._logoGradient.Color = config.gradient or DEFAULT_THEME.logo.gradient
+        self._logoGradient.Transparency = config.gradientTransparency or DEFAULT_THEME.logo.gradientTransparency
+        self._logoGradient.Rotation = config.gradientRotation or DEFAULT_THEME.logo.gradientRotation or 120
+    end
+
+    if self._logoGlyph then
+        self._logoGlyph.Image = config.glyphImage or (theme.iconography and theme.iconography.hologram) or ""
+        self._logoGlyph.ImageColor3 = config.glyphColor or theme.accentColor
+        self._logoGlyph.ImageTransparency = config.glyphTransparency or 0.2
+    end
+
+    if self._logoWordmark then
+        self._logoWordmark.Font = config.font or DEFAULT_THEME.logo.font
+        self._logoWordmark.TextSize = config.textSize or DEFAULT_THEME.logo.textSize
+        self._logoWordmark.Text = string.upper(config.text or DEFAULT_THEME.logo.text)
+        self._logoWordmark.TextColor3 = config.primaryColor or Color3.fromRGB(235, 245, 255)
+        self._logoWordmark.TextStrokeColor3 = config.textStrokeColor or Color3.fromRGB(10, 12, 24)
+        self._logoWordmark.TextStrokeTransparency = config.textStrokeTransparency or 0.6
+    end
+
+    if self._logoWordmarkGradient then
+        self._logoWordmarkGradient.Color = config.textGradient or DEFAULT_THEME.logo.textGradient
+        self._logoWordmarkGradient.Rotation = config.textGradientRotation or DEFAULT_THEME.logo.textGradientRotation or 0
+    end
+
+    if self._logoTagline then
+        self._logoTagline.Font = config.taglineFont or DEFAULT_THEME.logo.taglineFont
+        self._logoTagline.TextSize = config.taglineTextSize or DEFAULT_THEME.logo.taglineTextSize
+        self._logoTagline.TextColor3 = config.taglineColor or DEFAULT_THEME.logo.taglineColor
+        self._logoTagline.TextTransparency = config.taglineTransparency or DEFAULT_THEME.logo.taglineTransparency or 0
+        self._logoTagline.Text = config.tagline or DEFAULT_THEME.logo.tagline
+    end
+end
+
+function VerificationDashboard:destroy()
+    if self._destroyed then
+        return
+    end
+    self._destroyed = true
+
+    self:_stopLogoShimmer()
+
+    for _, connection in ipairs(self._actionConnections) do
+        if connection then
+            if connection.Disconnect then
+                connection:Disconnect()
+            elseif connection.disconnect then
+                connection:disconnect()
+            end
+        end
+    end
+
+    for _, button in ipairs(self._actionButtons) do
+        if button and button.Destroy then
+            button:Destroy()
+        end
+    end
+
+    if self._root then
+        self._root:Destroy()
+        self._root = nil
+    end
+end
+
+function VerificationDashboard:getRoot()
+    return self._root
+end
+
+function VerificationDashboard:getTheme()
+    return self._theme
+end
+
+function VerificationDashboard:applyTheme(theme)
+    if self._destroyed then
+        return
+    end
+
+    if theme then
+        self._theme = mergeTable(DEFAULT_THEME, theme)
+    end
+
+    local currentTheme = self._theme
+
+    self:_stopLogoShimmer()
+    self:_applyLogoTheme()
+
+    if self._title then
+        self._title.Font = currentTheme.titleFont
+        self._title.TextSize = currentTheme.titleTextSize
+    end
+    if self._subtitle then
+        self._subtitle.Font = currentTheme.subtitleFont
+        self._subtitle.TextSize = currentTheme.subtitleTextSize
+    end
+
+    if self._stepsFrame then
+        self._stepsFrame.Size = UDim2.new(1, 0, 1, -(currentTheme.actionHeight + 208))
+    end
+
+    if self._actionsFrame then
+        self._actionsFrame.Size = UDim2.new(1, 0, 0, currentTheme.actionHeight + 12)
+    end
+
+    for _, definition in ipairs(STEP_DEFINITIONS) do
+        local step = self._steps[definition.id]
+        if step then
+            step.frame.BackgroundColor3 = currentTheme.cardColor
+            step.frame.BackgroundTransparency = currentTheme.cardTransparency
+            if step.frame:FindFirstChildOfClass("UIStroke") then
+                local stroke = step.frame:FindFirstChildOfClass("UIStroke")
+                stroke.Color = currentTheme.cardStrokeColor
+                stroke.Transparency = currentTheme.cardStrokeTransparency
+            end
+            step.icon.ImageColor3 = currentTheme.pendingColor
+            step.icon.Image = currentTheme.iconography.pending
+            if step.iconGlow then
+                step.iconGlow.Color = currentTheme.pendingColor
+            end
+            step.title.Font = currentTheme.stepTitleFont
+            step.title.TextSize = currentTheme.stepTitleTextSize
+            step.status.Font = currentTheme.stepStatusFont
+            step.status.TextSize = currentTheme.stepStatusTextSize
+            step.connector.BackgroundColor3 = currentTheme.connectorColor
+            step.connector.BackgroundTransparency = currentTheme.connectorTransparency
+            if step.tooltip then
+                step.tooltip.Font = currentTheme.tooltipFont
+                step.tooltip.TextSize = currentTheme.tooltipTextSize
+                step.tooltip.BackgroundColor3 = currentTheme.tooltipBackground
+                step.tooltip.BackgroundTransparency = currentTheme.tooltipTransparency
+                step.tooltip.TextColor3 = currentTheme.tooltipTextColor
+            end
+        end
+    end
+
+    for _, connection in ipairs(self._actionConnections) do
+        if connection then
+            if connection.Disconnect then
+                connection:Disconnect()
+            elseif connection.disconnect then
+                connection:disconnect()
+            end
+        end
+    end
+    self._actionConnections = {}
+
+    for _, button in ipairs(self._actionButtons) do
+        if button and button.Destroy then
+            button:Destroy()
+        end
+    end
+    self._actionButtons = {}
+
+    if self._actions then
+        self:setActions(self._actions)
+    end
+
+    self:_startLogoShimmer()
+end
+
+function VerificationDashboard:setStatusText(text)
+    if self._destroyed then
+        return
+    end
+    if self._subtitle then
+        self._subtitle.Text = text or ""
+    end
+end
+
+function VerificationDashboard:setProgress(alpha)
+    if self._destroyed then
+        return
+    end
+
+    alpha = math.clamp(alpha or 0, 0, 1)
+
+    if self._progressTween then
+        self._progressTween:Cancel()
+        self._progressTween = nil
+    end
+
+    if not self._progressFill then
+        return
+    end
+
+    local tween = TweenService:Create(self._progressFill, TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+        Size = UDim2.new(alpha, 0, 1, 0),
+    })
+    self._progressTween = tween
+    tween:Play()
+end
+
+function VerificationDashboard:reset()
+    if self._destroyed then
+        return
+    end
+
+    for _, definition in ipairs(STEP_DEFINITIONS) do
+        local step = self._steps[definition.id]
+        if step then
+            step.state = "pending"
+            step.priority = STATUS_PRIORITY.pending
+            step.status.Text = definition.description
+            if step.iconTween then
+                step.iconTween:Cancel()
+                step.iconTween = nil
+            end
+            step.icon.Image = self._theme.iconography.pending
+            step.icon.ImageColor3 = self._theme.pendingColor
+            if step.iconGlow then
+                step.iconGlow.Color = self._theme.pendingColor
+            end
+            step.connector.BackgroundTransparency = self._theme.connectorTransparency
+            step.connector.BackgroundColor3 = self._theme.connectorColor
+            if step.tooltip then
+                step.tooltip.Text = definition.tooltip
+            end
+        end
+        self._stepStates[definition.id] = { status = "pending", priority = STATUS_PRIORITY.pending }
+    end
+
+    self:setProgress(0)
+    self:setStatusText("Preparing AutoParry systems…")
+end
+
+local function resolveStyle(theme, status)
+    local resolver = STATUS_STYLE[status]
+    if resolver then
+        return resolver(theme)
+    end
+    return STATUS_STYLE.pending(theme)
+end
+
+function VerificationDashboard:_applyStepState(id, status, message, tooltip)
+    if self._destroyed then
+        return
+    end
+
+    local step = self._steps[id]
+    if not step then
+        return
+    end
+
+    local current = self._stepStates[id]
+    current = current or { status = "pending", priority = STATUS_PRIORITY.pending }
+    local newPriority = STATUS_PRIORITY[status] or STATUS_PRIORITY.pending
+    if current.priority and current.priority > newPriority then
+        return
+    end
+
+    self._stepStates[id] = { status = status, priority = newPriority }
+
+    local style = resolveStyle(self._theme, status)
+
+    local label = message or style.label
+    if label and label ~= "" then
+        step.status.Text = label
+    end
+
+    if tooltip and step.tooltip then
+        step.tooltip.Text = tooltip
+    end
+
+    if step.iconTween then
+        step.iconTween:Cancel()
+        step.iconTween = nil
+    end
+
+    if style.icon then
+        step.icon.Image = style.icon
+    end
+
+    local tween = TweenService:Create(step.icon, TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+        ImageColor3 = style.color,
+        ImageTransparency = 0,
+    })
+    step.iconTween = tween
+    tween:Play()
+
+    if step.iconGlow then
+        step.iconGlow.Color = style.color
+        step.iconGlow.Transparency = 0.35
+    end
+
+    if step.connector then
+        step.connector.BackgroundColor3 = style.color
+        step.connector.BackgroundTransparency = status == "pending" and self._theme.connectorTransparency or 0.15
+    end
+
+    step.state = status
+end
+
+local function formatElapsed(seconds)
+    if not seconds or seconds <= 0 then
+        return nil
+    end
+    if seconds < 1 then
+        return string.format("%.2f s", seconds)
+    end
+    return string.format("%.1f s", seconds)
+end
+
+function VerificationDashboard:_applyParrySnapshot(snapshot)
+    if typeof(snapshot) ~= "table" then
+        return
+    end
+
+    local stage = snapshot.stage
+    local status = snapshot.status
+    local target = snapshot.target or snapshot.step
+
+    if stage == "ready" then
+        self:_applyStepState("player", "ok", "Player locked")
+        self:_applyStepState("remotes", "ok", string.format("%s (%s)", snapshot.remoteName or "Parry remote", snapshot.remoteVariant or "detected"))
+        if snapshot.successEvents then
+            self:_applyStepState("success", "ok", "Success listeners wired")
+        else
+            self:_applyStepState("success", "ok", "Success listeners active")
+        end
+        if snapshot.successEvents and snapshot.successEvents.Balls then
+            self:_applyStepState("balls", "ok", "Ball telemetry streaming")
+        else
+            self:_applyStepState("balls", "ok", "Ready for match")
+        end
+        return
+    end
+
+    if stage == "timeout" then
+        local reason = snapshot.reason or target
+        if reason == "local-player" or target == "local-player" then
+            self:_applyStepState("player", "failed", "Timed out waiting for player")
+        elseif reason == "remotes-folder" or target == "folder" then
+            self:_applyStepState("remotes", "failed", "Remotes folder missing")
+        elseif reason == "parry-remote" or target == "remote" then
+            self:_applyStepState("remotes", "failed", "Parry remote unavailable")
+        elseif reason == "balls-folder" then
+            self:_applyStepState("balls", "warning", "Balls folder not found")
+        end
+        return
+    end
+
+    if stage == "error" then
+        if target == "remote" then
+            self:_applyStepState("remotes", "failed", snapshot.message or "Unsupported parry remote")
+        elseif target == "folder" then
+            self:_applyStepState("remotes", "failed", snapshot.message or "Remotes folder removed")
+        else
+            self:_applyStepState("success", "warning", snapshot.message or "Verification error")
+        end
+        return
+    end
+
+    if stage == "waiting-player" then
+        if status == "ok" then
+            local elapsed = formatElapsed(snapshot.elapsed)
+            self:_applyStepState("player", "ok", elapsed and ("Player ready (" .. elapsed .. ")") or "Player ready")
+        elseif status == "waiting" or status == "pending" then
+            self:_applyStepState("player", "active", "Waiting for player…")
+        end
+        return
+    end
+
+    if stage == "waiting-remotes" then
+        if target == "folder" then
+            if status == "ok" then
+                self:_applyStepState("remotes", "active", "Remotes folder located")
+            elseif status == "waiting" or status == "pending" then
+                self:_applyStepState("remotes", "active", "Searching for Remotes folder…")
+            end
+        elseif target == "remote" then
+            if status == "ok" then
+                local name = snapshot.remoteName or "Parry remote"
+                local variant = snapshot.remoteVariant or "detected"
+                self:_applyStepState("remotes", "ok", string.format("%s (%s)", name, variant))
+            elseif status == "waiting" or status == "pending" then
+                self:_applyStepState("remotes", "active", "Scanning for parry remote…")
+            end
+        end
+        return
+    end
+
+    if stage == "verifying-success-remotes" then
+        self:_applyStepState("success", "active", "Hooking success events…")
+        if snapshot.remotes then
+            self:_applyStepState("success", "ok", "Success listeners bound")
+        end
+        return
+    end
+
+    if stage == "verifying-balls" then
+        if status == "ok" then
+            self:_applyStepState("balls", "ok", "Ball telemetry online")
+        elseif status == "waiting" then
+            self:_applyStepState("balls", "active", "Searching for balls…")
+        elseif status == "warning" then
+            self:_applyStepState("balls", "warning", "Ball folder timeout", "AutoParry will continue without ball telemetry if the folder is missing.")
+        end
+        return
+    end
+end
+
+local function extractErrorReason(errorState)
+    if typeof(errorState) ~= "table" then
+        return nil, nil
+    end
+
+    local payload = errorState.payload
+    local reason = errorState.reason
+    if payload and typeof(payload) == "table" then
+        reason = payload.reason or payload.target or payload.step or reason
+    end
+
+    return reason, payload
+end
+
+function VerificationDashboard:_applyError(errorState)
+    if not errorState then
+        return
+    end
+
+    local reason, payload = extractErrorReason(errorState)
+    local message = errorState.message or "Verification error"
+
+    if reason == "local-player" then
+        self:_applyStepState("player", "failed", message)
+    elseif reason == "remotes-folder" or reason == "parry-remote" or reason == "remote" then
+        self:_applyStepState("remotes", "failed", message)
+    elseif reason == "balls-folder" or reason == "balls" then
+        self:_applyStepState("balls", "warning", message)
+    else
+        self:_applyStepState("success", "warning", message)
+    end
+
+    if payload and payload.elapsed then
+        self:setStatusText(string.format("Failed after %s", formatElapsed(payload.elapsed) or "0 s"))
+    else
+        self:setStatusText(message)
+    end
+end
+
+function VerificationDashboard:update(state, context)
+    if self._destroyed then
+        return
+    end
+
+    state = state or {}
+
+    if state.parry then
+        self:_applyParrySnapshot(state.parry)
+    elseif state.stage then
+        self:_applyParrySnapshot(state)
+    end
+
+    if state.error then
+        self:_applyError(state.error)
+    end
+
+    if context and context.progress then
+        self:setProgress(context.progress)
+    end
+end
+
+function VerificationDashboard:setActions(actions)
+    if self._destroyed then
+        return
+    end
+
+    self._actions = actions
+
+    for _, connection in ipairs(self._actionConnections) do
+        if connection then
+            if connection.Disconnect then
+                connection:Disconnect()
+            elseif connection.disconnect then
+                connection:disconnect()
+            end
+        end
+    end
+    self._actionConnections = {}
+
+    for _, button in ipairs(self._actionButtons) do
+        if button and button.Destroy then
+            button:Destroy()
+        end
+    end
+    self._actionButtons = {}
+
+    if typeof(actions) ~= "table" or #actions == 0 then
+        if self._actionsFrame then
+            self._actionsFrame.Visible = false
+        end
+        return
+    end
+
+    if not self._actionsFrame then
+        return
+    end
+
+    self._actionsFrame.Visible = true
+
+    for index, action in ipairs(actions) do
+        local button = Instance.new("TextButton")
+        button.Name = action.id or action.name or string.format("Action%d", index)
+        button.Text = action.text or action.label or "Action"
+        button.BackgroundTransparency = 0
+        button.ZIndex = 5
+        button.Parent = self._actionsFrame
+
+        styleActionButton(button, self._theme, action)
+
+        local connection
+        if typeof(action.callback) == "function" then
+            connection = button.MouseButton1Click:Connect(function()
+                action.callback(self, action)
+            end)
+        end
+
+        table.insert(self._actionButtons, button)
+        table.insert(self._actionConnections, connection)
+    end
+end
+
+return VerificationDashboard


### PR DESCRIPTION
## Summary
- remove the verification dashboard screenshot asset so the experience relies on its in-game styling
- add a configurable holographic logo badge, header layout, and shimmer animation to the verification dashboard theme
- fix loading overlay theme constants so the spinner asset resolves correctly when theming updates

## Testing
- selene src *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e540285464832aba2cbe2d94bc8fe2