### PR TITLE
Use ParryButtonPress bindable for parry invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ events with the neon verification dashboard above so players can follow each
 stage:
 
 - **Player Sync** — waits for `Players.LocalPlayer` and the character rig.
-- **Remotes** — locates `ReplicatedStorage.Remotes` and validates the parry
-  remote (`ParryButtonPress` or the legacy `ParryAttempt`).
+- **Remotes** — locates `ReplicatedStorage.Remotes` and validates the
+  `ParryButtonPress.parryButtonPress` bindable used to trigger parries.
 - **Success Events** — wires listeners for `ParrySuccess` / `ParrySuccessAll`
   so the core can reset cooldowns as soon as Blade Ball confirms a parry.
 - **Ball Telemetry** — verifies the configured workspace folder (defaults to
@@ -225,7 +225,8 @@ Call `resetConfig()` to restore defaults at runtime.
 
 ## Reliability safeguards
 
-- The core waits for the local player and the `ParryButtonPress` remote with a
+- The core waits for the local player and the `ParryButtonPress.parryButtonPress`
+  bindable with a
   sensible timeout before starting the heartbeat loop, raising a clear error if
   Blade Ball is not ready yet.
 - Config overrides are validated to prevent invalid values from breaking the

--- a/src/core/autoparry.lua
+++ b/src/core/autoparry.lua
@@ -209,7 +209,7 @@ local handleParryRemoteInvalidated
 local disconnectParryRemoteMonitors
 local scheduleParryRemoteRestart
 
-local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress", "ParryAttempt" }
+local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress.parryButtonPress" }
 
 local function disconnectSuccessListeners()
     safeDisconnect(ParrySuccessConnection)
@@ -426,24 +426,11 @@ local function configureParryRemoteInvoker(remoteInfo)
         return
     end
 
-    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
-    if not variant and ParryRemote then
-        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
-    end
-
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant or "modern"
     ParryRemoteVariant = variant
 
-    if variant == "legacy" then
-        ParryRemoteFire = function(ball, analysis)
-            local context = createLegacyContext(ball, analysis)
-            local payload = buildLegacyPayload(context)
-            local length = payload.n or #payload
-            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
-        end
-    else
-        ParryRemoteFire = function()
-            return ParryRemoteBaseFire()
-        end
+    ParryRemoteFire = function()
+        return ParryRemoteBaseFire()
     end
 end
 
@@ -508,8 +495,12 @@ local function beginInitialization()
                 report = report,
                 retryInterval = config.verificationRetryInterval,
                 candidates = {
-                    { name = "ParryButtonPress", variant = "modern" },
-                    { name = "ParryAttempt", variant = "legacy" },
+                    {
+                        name = "ParryButtonPress",
+                        childName = "parryButtonPress",
+                        variant = "modern",
+                        displayName = "ParryButtonPress.parryButtonPress",
+                    },
                 },
             })
         end)

--- a/tests/autoparry/config.spec.lua
+++ b/tests/autoparry/config.spec.lua
@@ -21,7 +21,7 @@ local function loadAutoparry()
         initialLocalPlayer = { Name = "LocalPlayer" },
     })
 
-    remotes:Add(Harness.createRemote())
+    remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
     local autoparry = Harness.loadAutoparry({
         scheduler = scheduler,

--- a/tests/autoparry/destroy.spec.lua
+++ b/tests/autoparry/destroy.spec.lua
@@ -165,8 +165,8 @@ return function(t)
                 runService = runServiceProbe,
             })
 
-            local remote1 = Harness.createRemote()
-            remotes1:Add(remote1)
+            local remoteContainer1 = Harness.createParryButtonPress({ scheduler = scheduler1 })
+            remotes1:Add(remoteContainer1)
 
             local autoparry1 = Harness.loadAutoparry({
                 scheduler = scheduler1,
@@ -247,8 +247,8 @@ return function(t)
                 runService = runServiceProbe,
             })
 
-            local remote2 = Harness.createRemote()
-            remotes2:Add(remote2)
+            local remoteContainer2 = Harness.createParryButtonPress({ scheduler = scheduler2 })
+            remotes2:Add(remoteContainer2)
 
             local autoparry2 = Harness.loadAutoparry({
                 scheduler = scheduler2,

--- a/tests/autoparry/evaluate_ball.spec.lua
+++ b/tests/autoparry/evaluate_ball.spec.lua
@@ -178,7 +178,7 @@ local function createContext()
         initialLocalPlayer = { Name = "LocalPlayer" },
     })
 
-    remotes:Add(Harness.createRemote())
+    remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
     local autoparry = Harness.loadAutoparry({
         scheduler = scheduler,

--- a/tests/autoparry/harness.lua
+++ b/tests/autoparry/harness.lua
@@ -237,6 +237,30 @@ function Harness.createRemote(options)
     return remote
 end
 
+function Harness.createParryButtonPress(options)
+    options = options or {}
+    local scheduler = options.scheduler
+    if not scheduler then
+        error("createParryButtonPress requires a scheduler", 0)
+    end
+
+    local containerName = options.name or "ParryButtonPress"
+    local childName = options.childName or "parryButtonPress"
+    local container = createContainer(scheduler, containerName)
+    container.ClassName = options.className or "Folder"
+
+    local remote = Harness.createRemote({
+        kind = options.remoteKind or "BindableEvent",
+        name = childName,
+        className = options.remoteClassName,
+    })
+
+    container:Add(remote)
+    container._parryRemote = remote
+
+    return container, remote
+end
+
 function Harness.fireRemoteClient(remote, ...)
     if not remote then
         return

--- a/tests/autoparry/heartbeat.spec.lua
+++ b/tests/autoparry/heartbeat.spec.lua
@@ -130,20 +130,20 @@ return function(t)
             runService = runService,
         })
 
-        local remote = Harness.createRemote()
-        remotes:Add(remote)
+        local remoteContainer, remote = Harness.createParryButtonPress({ scheduler = scheduler })
+        remotes:Add(remoteContainer)
 
         local parryLog = {}
         local currentFrame = 0
 
-        local originalFireServer = remote.FireServer
-        remote.FireServer = function(self, ...)
+        local originalFire = remote.Fire
+        remote.Fire = function(self, ...)
             table.insert(parryLog, {
                 frame = currentFrame,
                 time = scheduler:clock(),
                 payload = { ... },
             })
-            return originalFireServer(self, ...)
+            return originalFire(self, ...)
         end
 
         local autoparry = Harness.loadAutoparry({

--- a/tests/autoparry/parry_loop.spec.lua
+++ b/tests/autoparry/parry_loop.spec.lua
@@ -190,8 +190,13 @@ local function createContext(options)
         stats = stats,
     })
 
-    local remote = Harness.createRemote(options.remote)
-    remotes:Add(remote)
+    local remoteOptions = options.remote or {}
+    local parryContainer, remote = Harness.createParryButtonPress({
+        scheduler = scheduler,
+        remoteKind = remoteOptions.kind,
+        remoteClassName = remoteOptions.className,
+    })
+    remotes:Add(parryContainer)
 
     local ballsFolder = BallsFolder.new("Balls")
 
@@ -247,16 +252,22 @@ local function createContext(options)
 
     local context
 
-    local function setActiveRemote(remoteInstance)
+    local activeRemoteContainer = parryContainer
+
+    local function setActiveRemote(remoteInstance, containerInstance)
         local methodName = hookRemote(remoteInstance)
+        if containerInstance then
+            activeRemoteContainer = containerInstance
+        end
         if context then
             context.remote = remoteInstance
             context.remoteMethod = methodName
+            context.remoteContainer = activeRemoteContainer
         end
         return methodName
     end
 
-    local parryMethodName = setActiveRemote(remote)
+    local parryMethodName = setActiveRemote(remote, parryContainer)
 
     local parryLog = {}
     local parryConnection = autoparry.onParry(function(ball, timestamp)
@@ -272,6 +283,7 @@ local function createContext(options)
         autoparry = autoparry,
         remote = remote,
         remoteMethod = parryMethodName,
+        remoteContainer = parryContainer,
         remotes = remotes,
         remoteLog = remoteLog,
         parryLog = parryLog,
@@ -313,15 +325,17 @@ local function createContext(options)
             return nil
         end
 
-        local targetName = self.remote and self.remote.Name
+        local container = self.remoteContainer
+        local targetName = container and container.Name
         if not targetName then
             return nil
         end
 
         local removed = self.remotes:Remove(targetName)
-        if removed == self.remote then
+        if removed == container then
             self.remote = nil
             self.remoteMethod = nil
+            self.remoteContainer = nil
         end
 
         return removed
@@ -332,11 +346,16 @@ local function createContext(options)
             return nil
         end
 
-        local newRemote = Harness.createRemote(remoteOptions)
-        self.remotes:Add(newRemote)
-        local methodName = setActiveRemote(newRemote)
+        local newContainer, newRemote = Harness.createParryButtonPress({
+            scheduler = scheduler,
+            remoteKind = remoteOptions and remoteOptions.kind,
+            remoteClassName = remoteOptions and remoteOptions.className,
+        })
+        self.remotes:Add(newContainer)
+        local methodName = setActiveRemote(newRemote, newContainer)
         self.remote = newRemote
         self.remoteMethod = methodName
+        self.remoteContainer = newContainer
         return newRemote
     end
 
@@ -460,87 +479,6 @@ return function(t)
 
         expect(#context.parryLog).toEqual(1)
         expect(context.parryLog[1].ball).toEqual(ball)
-
-        context:destroy()
-    end)
-
-    t.test("parry loop fires bindable parry remotes", function(expect)
-        local context = createContext({
-            remote = {
-                kind = "BindableEvent",
-            },
-        })
-
-        local autoparry = context.autoparry
-
-        autoparry.resetConfig()
-        autoparry.configure({
-            minTTI = 0,
-            pingOffset = 0,
-            cooldown = 0.12,
-        })
-
-        local ball = context:addBall({
-            name = "BindableThreat",
-            position = Vector3.new(0, 0, 36),
-            velocity = Vector3.new(0, 0, -180),
-        })
-
-        autoparry.setEnabled(true)
-        context:step(1 / 60)
-
-        expect(#context.parryLog).toEqual(1)
-        expect(context.parryLog[1].ball).toEqual(ball)
-        expect(context.remoteMethod).toEqual("Fire")
-        expect(#context.remoteLog).toEqual(1)
-        expect(context.remote.lastPayload).toEqual({})
-
-        context:destroy()
-    end)
-
-    t.test("parry loop builds a legacy parry attempt payload", function(expect)
-        local context = createContext({
-            remote = {
-                name = "ParryAttempt",
-                kind = "RemoteEvent",
-            },
-        })
-
-        local autoparry = context.autoparry
-
-        autoparry.resetConfig()
-        autoparry.configure({
-            minTTI = 0,
-            pingOffset = 0,
-            cooldown = 0.12,
-        })
-
-        local ball = context:addBall({
-            name = "LegacyThreat",
-            position = Vector3.new(0, 0, 36),
-            velocity = Vector3.new(0, 0, -180),
-        })
-
-        autoparry.setEnabled(true)
-        context:step(1 / 60)
-
-        expect(#context.parryLog).toEqual(1)
-        expect(context.parryLog[1].ball).toEqual(ball)
-        expect(context.remoteMethod).toEqual("FireServer")
-
-        local payload = context.remote.lastPayload
-        expect(#payload).toEqual(5)
-        expect(type(payload[1])).toEqual("number")
-        expect(payload[2]).toEqual(ball.CFrame)
-        expect(type(payload[4])).toEqual("number")
-        expect(type(payload[5])).toEqual("number")
-
-        local snapshot = payload[3]
-        expect(type(snapshot)).toEqual("table")
-        local localEntry = snapshot["LocalPlayer"]
-        expect(type(localEntry)).toEqual("table")
-        expect(localEntry.position).toEqual(context.rootPart.Position)
-        expect(localEntry.velocity).toEqual(context.rootPart.AssemblyLinearVelocity)
 
         context:destroy()
     end)

--- a/tests/autoparry/ping.spec.lua
+++ b/tests/autoparry/ping.spec.lua
@@ -64,7 +64,7 @@ return function(t)
             stats = stats,
         })
 
-        remotes:Add(Harness.createRemote())
+        remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
         local autoparry = Harness.loadAutoparry({
             scheduler = scheduler,

--- a/tests/autoparry/verification_status.spec.lua
+++ b/tests/autoparry/verification_status.spec.lua
@@ -32,7 +32,7 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            remotes:Add(Harness.createRemote())
+            remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -100,7 +100,7 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            remotes:Add(Harness.createRemote())
+            remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -161,8 +161,8 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            local parryRemote = Harness.createRemote()
-            remotes:Add(parryRemote)
+            local parryContainer = Harness.createParryButtonPress({ scheduler = scheduler })
+            remotes:Add(parryContainer)
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -177,11 +177,11 @@ return function(t)
             local ready = waitForStage(scheduler, autoparry, "ready")
             expect(ready.remoteName):toEqual("ParryButtonPress")
 
-            remotes:Remove(parryRemote.Name)
+            remotes:Remove(parryContainer.Name)
             scheduler:wait()
 
             scheduler:schedule(2, function()
-                remotes:Add(Harness.createRemote())
+                remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
             end)
 
             local readyAgain = waitForStage(scheduler, autoparry, "ready", 80)

--- a/tests/fixtures/AutoParrySourceMap.lua
+++ b/tests/fixtures/AutoParrySourceMap.lua
@@ -29,6 +29,22 @@ local function isCallable(value)
     return typeOf(value) == "function"
 end
 
+local function getClassName(instance)
+    if instance == nil then
+        return "nil"
+    end
+
+    local okClass, className = pcall(function()
+        return instance.ClassName
+    end)
+
+    if okClass and type(className) == "string" then
+        return className
+    end
+
+    return typeOf(instance)
+end
+
 local function cloneTable(tbl)
     local result = {}
     for key, value in pairs(tbl) do
@@ -298,8 +314,9 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
     local candidateNames = {}
 
     for _, entry in ipairs(candidates) do
+        local displayName = entry.displayName or entry.name
         table.insert(candidateDefinitions, entry)
-        table.insert(candidateNames, entry.name)
+        table.insert(candidateNames, displayName)
     end
 
     emit(report, {
@@ -318,32 +335,22 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
             return nil
         end
 
-        local isEvent, className = isRemoteEvent(found)
-        if not isEvent then
-            emit(report, {
-                stage = "error",
-                target = "remote",
-                status = "failed",
-                reason = "parry-remote-unsupported",
-                className = className,
-                remoteName = found.Name,
-                candidates = candidateNames,
-                message = string.format(
-                    "AutoParry: parry remote unsupported type (%s)",
-                    className
-                ),
-            })
+        local remote = found
+        local containerName = nil
 
-            error(
-                string.format(
-                    "AutoParry: parry remote unsupported type (%s)",
-                    className
-                ),
-                0
-            )
+        if candidate.childName then
+            local okChild, child = pcall(found.FindFirstChild, found, candidate.childName)
+            if not okChild or not child then
+                return nil
+            end
+
+            remote = child
+            containerName = found.Name
         end
 
-        local methodName, fire = findRemoteFire(found)
+        local className = getClassName(remote)
+
+        local methodName, fire = findRemoteFire(remote)
         if not methodName or not fire then
             emit(report, {
                 stage = "error",
@@ -351,7 +358,7 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
                 status = "failed",
                 reason = "parry-remote-missing-method",
                 className = className,
-                remoteName = found.Name,
+                remoteName = remote.Name,
                 candidates = candidateNames,
                 message = "AutoParry: parry remote missing FireServer/Fire",
             })
@@ -361,13 +368,15 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
 
         local info = {
             method = methodName,
-            kind = "RemoteEvent",
             className = className,
-            remoteName = found.Name,
+            kind = className,
+            remoteName = candidate.name,
+            remoteChildName = remote.Name,
+            remoteContainerName = containerName,
             variant = candidate.variant,
         }
 
-        return true, found, fire, info
+        return true, remote, fire, info
     end
 
     while true do
@@ -409,7 +418,7 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
                 candidates = candidateNames,
             })
 
-            error("AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)", 0)
+            error("AutoParry: parry remote missing (ParryButtonPress.parryButtonPress)", 0)
         end
 
         waitInterval(retryInterval)
@@ -522,8 +531,12 @@ function Verification.run(options)
     local retryInterval = options.retryInterval or config.verificationRetryInterval or 0
 
     local candidateDefinitions = options.candidates or {
-        { name = "ParryButtonPress", variant = "modern" },
-        { name = "ParryAttempt", variant = "legacy" },
+        {
+            name = "ParryButtonPress",
+            childName = "parryButtonPress",
+            variant = "modern",
+            displayName = "ParryButtonPress.parryButtonPress",
+        },
     }
 
     local playerTimeout = config.playerTimeout or options.playerTimeout or 10
@@ -561,7 +574,6 @@ function Verification.run(options)
 end
 
 return Verification
-
 ]===],
     ['src/core/autoparry.lua'] = [===[
 -- mikkel32/AutoParry : src/core/autoparry.lua
@@ -775,7 +787,7 @@ local handleParryRemoteInvalidated
 local disconnectParryRemoteMonitors
 local scheduleParryRemoteRestart
 
-local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress", "ParryAttempt" }
+local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress.parryButtonPress" }
 
 local function disconnectSuccessListeners()
     safeDisconnect(ParrySuccessConnection)
@@ -992,24 +1004,11 @@ local function configureParryRemoteInvoker(remoteInfo)
         return
     end
 
-    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
-    if not variant and ParryRemote then
-        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
-    end
-
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant or "modern"
     ParryRemoteVariant = variant
 
-    if variant == "legacy" then
-        ParryRemoteFire = function(ball, analysis)
-            local context = createLegacyContext(ball, analysis)
-            local payload = buildLegacyPayload(context)
-            local length = payload.n or #payload
-            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
-        end
-    else
-        ParryRemoteFire = function()
-            return ParryRemoteBaseFire()
-        end
+    ParryRemoteFire = function()
+        return ParryRemoteBaseFire()
     end
 end
 
@@ -1074,8 +1073,12 @@ local function beginInitialization()
                 report = report,
                 retryInterval = config.verificationRetryInterval,
                 candidates = {
-                    { name = "ParryButtonPress", variant = "modern" },
-                    { name = "ParryAttempt", variant = "legacy" },
+                    {
+                        name = "ParryButtonPress",
+                        childName = "parryButtonPress",
+                        variant = "modern",
+                        displayName = "ParryButtonPress.parryButtonPress",
+                    },
                 },
             })
         end)
@@ -2026,7 +2029,6 @@ end
 ensureInitialization()
 
 return AutoParry
-
 ]===],
     ['src/main.lua'] = [===[
 -- mikkel32/AutoParry : src/main.lua


### PR DESCRIPTION
## Summary
- update parry discovery to use the ReplicatedStorage.Remotes.ParryButtonPress.parryButtonPress bindable exclusively
- adjust the runtime harness/tests to model the new parry button binding and remove legacy ParryAttempt coverage
- refresh documentation and the source map to describe the new parry remote structure

## Testing
- Not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68e555c59e58832a845d582ed27c9e5d