### PR TITLE
Fix parry button invocation to use ParryButtonPress bindable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ events with the neon verification dashboard above so players can follow each
 stage:
 
 - **Player Sync** — waits for `Players.LocalPlayer` and the character rig.
-- **Remotes** — locates `ReplicatedStorage.Remotes` and validates the parry
-  remote (`ParryButtonPress` or the legacy `ParryAttempt`).
+- **Remotes** — locates `ReplicatedStorage.Remotes` and validates the
+  `ParryButtonPress.parryButtonPress` bindable used to trigger parries.
 - **Success Events** — wires listeners for `ParrySuccess` / `ParrySuccessAll`
   so the core can reset cooldowns as soon as Blade Ball confirms a parry.
 - **Ball Telemetry** — verifies the configured workspace folder (defaults to
@@ -225,7 +225,8 @@ Call `resetConfig()` to restore defaults at runtime.
 
 ## Reliability safeguards
 
-- The core waits for the local player and the `ParryButtonPress` remote with a
+- The core waits for the local player and the `ParryButtonPress.parryButtonPress`
+  bindable with a
   sensible timeout before starting the heartbeat loop, raising a clear error if
   Blade Ball is not ready yet.
 - Config overrides are validated to prevent invalid values from breaking the

--- a/src/core/autoparry.lua
+++ b/src/core/autoparry.lua
@@ -209,7 +209,7 @@ local handleParryRemoteInvalidated
 local disconnectParryRemoteMonitors
 local scheduleParryRemoteRestart
 
-local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress", "ParryAttempt" }
+local PARRY_REMOTE_CANDIDATES = { "ParryButtonPress.parryButtonPress" }
 
 local function disconnectSuccessListeners()
     safeDisconnect(ParrySuccessConnection)
@@ -426,24 +426,11 @@ local function configureParryRemoteInvoker(remoteInfo)
         return
     end
 
-    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant
-    if not variant and ParryRemote then
-        variant = ParryRemote.Name == "ParryAttempt" and "legacy" or "modern"
-    end
-
+    local variant = remoteInfo and remoteInfo.variant or ParryRemoteVariant or "modern"
     ParryRemoteVariant = variant
 
-    if variant == "legacy" then
-        ParryRemoteFire = function(ball, analysis)
-            local context = createLegacyContext(ball, analysis)
-            local payload = buildLegacyPayload(context)
-            local length = payload.n or #payload
-            return ParryRemoteBaseFire(arrayUnpack(payload, 1, length))
-        end
-    else
-        ParryRemoteFire = function()
-            return ParryRemoteBaseFire()
-        end
+    ParryRemoteFire = function()
+        return ParryRemoteBaseFire()
     end
 end
 
@@ -508,8 +495,12 @@ local function beginInitialization()
                 report = report,
                 retryInterval = config.verificationRetryInterval,
                 candidates = {
-                    { name = "ParryButtonPress", variant = "modern" },
-                    { name = "ParryAttempt", variant = "legacy" },
+                    {
+                        name = "ParryButtonPress",
+                        childName = "parryButtonPress",
+                        variant = "modern",
+                        displayName = "ParryButtonPress.parryButtonPress",
+                    },
                 },
             })
         end)
@@ -1110,7 +1101,7 @@ local function tryParry(ball, analysis)
     end
 
     state.lastParry = now
-    ParryRemoteFire(ball, analysis)
+    ParryRemoteFire()
     parryEvent:fire(ball, now)
     log("AutoParry: fired parry for", ball)
     return true

--- a/src/core/verification.lua
+++ b/src/core/verification.lua
@@ -26,6 +26,22 @@ local function isCallable(value)
     return typeOf(value) == "function"
 end
 
+local function getClassName(instance)
+    if instance == nil then
+        return "nil"
+    end
+
+    local okClass, className = pcall(function()
+        return instance.ClassName
+    end)
+
+    if okClass and type(className) == "string" then
+        return className
+    end
+
+    return typeOf(instance)
+end
+
 local function cloneTable(tbl)
     local result = {}
     for key, value in pairs(tbl) do
@@ -77,7 +93,7 @@ local function createRemoteFireWrapper(remote, methodName)
         if not isCallable(current) then
             error(
                 string.format(
-                    "AutoParry: parry remote missing %s",
+                    "AutoParry: parry button missing %s",
                     methodName
                 ),
                 0
@@ -89,13 +105,6 @@ local function createRemoteFireWrapper(remote, methodName)
 end
 
 local function findRemoteFire(remote)
-    local okServer, fireServer = pcall(function()
-        return remote.FireServer
-    end)
-    if okServer and isCallable(fireServer) then
-        return "FireServer", createRemoteFireWrapper(remote, "FireServer")
-    end
-
     local okFire, fire = pcall(function()
         return remote.Fire
     end)
@@ -295,8 +304,9 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
     local candidateNames = {}
 
     for _, entry in ipairs(candidates) do
+        local displayName = entry.displayName or entry.name
         table.insert(candidateDefinitions, entry)
-        table.insert(candidateNames, entry.name)
+        table.insert(candidateNames, displayName)
     end
 
     emit(report, {
@@ -315,32 +325,46 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
             return nil
         end
 
-        local isEvent, className = isRemoteEvent(found)
-        if not isEvent then
+        local remote = found
+        local containerName = nil
+
+        if candidate.childName then
+            local okChild, child = pcall(found.FindFirstChild, found, candidate.childName)
+            if not okChild or not child then
+                return nil
+            end
+
+            remote = child
+            containerName = found.Name
+        end
+
+        local className = getClassName(remote)
+
+        local okBindable, isBindable = pcall(function()
+            local isA = remote.IsA
+            if not isCallable(isA) then
+                return false
+            end
+
+            return isA(remote, "BindableEvent")
+        end)
+
+        if not okBindable or not isBindable then
             emit(report, {
                 stage = "error",
                 target = "remote",
                 status = "failed",
                 reason = "parry-remote-unsupported",
                 className = className,
-                remoteName = found.Name,
+                remoteName = remote.Name,
                 candidates = candidateNames,
-                message = string.format(
-                    "AutoParry: parry remote unsupported type (%s)",
-                    className
-                ),
+                message = "AutoParry: ParryButtonPress.parryButtonPress must be a BindableEvent",
             })
 
-            error(
-                string.format(
-                    "AutoParry: parry remote unsupported type (%s)",
-                    className
-                ),
-                0
-            )
+            error("AutoParry: ParryButtonPress.parryButtonPress must be a BindableEvent", 0)
         end
 
-        local methodName, fire = findRemoteFire(found)
+        local methodName, fire = findRemoteFire(remote)
         if not methodName or not fire then
             emit(report, {
                 stage = "error",
@@ -348,23 +372,25 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
                 status = "failed",
                 reason = "parry-remote-missing-method",
                 className = className,
-                remoteName = found.Name,
+                remoteName = remote.Name,
                 candidates = candidateNames,
-                message = "AutoParry: parry remote missing FireServer/Fire",
+                message = "AutoParry: ParryButtonPress.parryButtonPress missing Fire",
             })
 
-            error("AutoParry: parry remote missing FireServer/Fire", 0)
+            error("AutoParry: ParryButtonPress.parryButtonPress missing Fire", 0)
         end
 
         local info = {
             method = methodName,
-            kind = "RemoteEvent",
             className = className,
-            remoteName = found.Name,
+            kind = className,
+            remoteName = candidate.name,
+            remoteChildName = remote.Name,
+            remoteContainerName = containerName,
             variant = candidate.variant,
         }
 
-        return true, found, fire, info
+        return true, remote, fire, info
     end
 
     while true do
@@ -406,7 +432,7 @@ local function ensureParryRemote(report, remotes, timeout, retryInterval, candid
                 candidates = candidateNames,
             })
 
-            error("AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)", 0)
+            error("AutoParry: parry remote missing (ParryButtonPress.parryButtonPress)", 0)
         end
 
         waitInterval(retryInterval)
@@ -519,8 +545,12 @@ function Verification.run(options)
     local retryInterval = options.retryInterval or config.verificationRetryInterval or 0
 
     local candidateDefinitions = options.candidates or {
-        { name = "ParryButtonPress", variant = "modern" },
-        { name = "ParryAttempt", variant = "legacy" },
+        {
+            name = "ParryButtonPress",
+            childName = "parryButtonPress",
+            variant = "modern",
+            displayName = "ParryButtonPress.parryButtonPress",
+        },
     }
 
     local playerTimeout = config.playerTimeout or options.playerTimeout or 10

--- a/tests/autoparry/bootstrap.spec.lua
+++ b/tests/autoparry/bootstrap.spec.lua
@@ -23,7 +23,7 @@ return function(t)
     t.test("resolves the local player once it becomes available", function(expect)
         local scheduler = Scheduler.new(1)
         local services, remotes, players = Harness.createBaseServices(scheduler)
-        remotes:Add(Harness.createRemote())
+        remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
         local stubPlayer = { Name = "LocalPlayer" }
         scheduler:schedule(3, function()
@@ -68,7 +68,7 @@ return function(t)
         })
 
         scheduler:schedule(4, function()
-            remotes:Add(Harness.createRemote())
+            remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
         end)
 
         local autoparry = Harness.loadAutoparry({
@@ -110,7 +110,7 @@ return function(t)
     t.test("errors after 10 seconds when the local player never appears", function(expect)
         local scheduler = Scheduler.new(1)
         local services, remotes = Harness.createBaseServices(scheduler)
-        remotes:Add(Harness.createRemote())
+        remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
         local autoparry = Harness.loadAutoparry({
             scheduler = scheduler,
@@ -182,7 +182,7 @@ return function(t)
         end)
 
         expect(ok):toEqual(false)
-        expect(err):toEqual("AutoParry: parry remote missing (ParryButtonPress/ParryAttempt)")
+        expect(err):toEqual("AutoParry: parry remote missing (ParryButtonPress.parryButtonPress)")
     end)
 
     t.test("errors when the parry remote lacks a supported fire method", function(expect)
@@ -191,8 +191,10 @@ return function(t)
             initialLocalPlayer = { Name = "LocalPlayer" },
         })
 
-        local invalidRemote = { Name = "ParryButtonPress", ClassName = "Folder" }
-        remotes:Add(invalidRemote)
+        local invalidContainer, invalidChild = Harness.createParryButtonPress({ scheduler = scheduler })
+        invalidChild.Fire = nil
+        invalidChild.FireServer = nil
+        remotes:Add(invalidContainer)
 
         local autoparry = Harness.loadAutoparry({
             scheduler = scheduler,
@@ -203,16 +205,16 @@ return function(t)
 
         expect(progress.stage):toEqual("error")
         expect(progress.target):toEqual("remote")
-        expect(progress.reason):toEqual("parry-remote-unsupported")
-        expect(progress.className):toEqual("Folder")
-        expect(progress.message):toEqual("AutoParry: parry remote unsupported type (Folder)")
+        expect(progress.reason):toEqual("parry-remote-missing-method")
+        expect(progress.className):toEqual("BindableEvent")
+        expect(progress.message):toEqual("AutoParry: ParryButtonPress.parryButtonPress missing Fire")
 
         local ok, err = pcall(function()
             autoparry.enable()
         end)
 
         expect(ok):toEqual(false)
-        expect(err):toEqual("AutoParry: parry remote unsupported type (Folder)")
+        expect(err):toEqual("AutoParry: ParryButtonPress.parryButtonPress missing Fire")
     end)
 
     t.test("listens for parry success events when they exist", function(expect)
@@ -221,8 +223,8 @@ return function(t)
             initialLocalPlayer = { Name = "LocalPlayer" },
         })
 
-        local parryRemote = Harness.createRemote()
-        remotes:Add(parryRemote)
+        local parryContainer = Harness.createParryButtonPress({ scheduler = scheduler })
+        remotes:Add(parryContainer)
         local successRemote = Harness.createRemote({ name = "ParrySuccess" })
         remotes:Add(successRemote)
         local successAllRemote = Harness.createRemote({ name = "ParrySuccessAll" })
@@ -275,33 +277,14 @@ return function(t)
         autoparry.destroy()
     end)
 
-    t.test("falls back to the legacy parry attempt remote when the button press is missing", function(expect)
-        local scheduler = Scheduler.new(1)
-        local services, remotes = Harness.createBaseServices(scheduler, {
-            initialLocalPlayer = { Name = "LocalPlayer" },
-        })
-
-        remotes:Add(Harness.createRemote({ name = "ParryAttempt" }))
-
-        local autoparry = Harness.loadAutoparry({
-            scheduler = scheduler,
-            services = services,
-        })
-
-        local ready = waitForStage(scheduler, autoparry, "ready")
-
-        expect(ready.remoteName):toEqual("ParryAttempt")
-        expect(ready.remoteVariant):toEqual("legacy")
-    end)
-
     t.test("restarts initialization when the parry remote is removed", function(expect)
         local scheduler = Scheduler.new(1)
         local services, remotes = Harness.createBaseServices(scheduler, {
             initialLocalPlayer = { Name = "LocalPlayer" },
         })
 
-        local parryRemote = Harness.createRemote()
-        remotes:Add(parryRemote)
+        local parryContainer = Harness.createParryButtonPress({ scheduler = scheduler })
+        remotes:Add(parryContainer)
 
         local autoparry = Harness.loadAutoparry({
             scheduler = scheduler,
@@ -316,7 +299,7 @@ return function(t)
         local ready = waitForStage(scheduler, autoparry, "ready")
         expect(ready.remoteName):toEqual("ParryButtonPress")
 
-        remotes:Remove(parryRemote.Name)
+        remotes:Remove(parryContainer.Name)
         scheduler:wait()
 
         local sawRestart = false
@@ -333,9 +316,9 @@ return function(t)
         expect(restartDetails.reason):toEqual("parry-remote-removed")
         expect(restartDetails.remoteName):toEqual("ParryButtonPress")
 
-        scheduler:schedule(2, function()
-            remotes:Add(Harness.createRemote())
-        end)
+            scheduler:schedule(2, function()
+                remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
+            end)
 
         local readyAgain = waitForStage(scheduler, autoparry, "ready")
         expect(readyAgain.remoteName):toEqual("ParryButtonPress")

--- a/tests/autoparry/config.spec.lua
+++ b/tests/autoparry/config.spec.lua
@@ -21,7 +21,7 @@ local function loadAutoparry()
         initialLocalPlayer = { Name = "LocalPlayer" },
     })
 
-    remotes:Add(Harness.createRemote())
+    remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
     local autoparry = Harness.loadAutoparry({
         scheduler = scheduler,

--- a/tests/autoparry/destroy.spec.lua
+++ b/tests/autoparry/destroy.spec.lua
@@ -165,8 +165,8 @@ return function(t)
                 runService = runServiceProbe,
             })
 
-            local remote1 = Harness.createRemote()
-            remotes1:Add(remote1)
+            local remoteContainer1 = Harness.createParryButtonPress({ scheduler = scheduler1 })
+            remotes1:Add(remoteContainer1)
 
             local autoparry1 = Harness.loadAutoparry({
                 scheduler = scheduler1,
@@ -247,8 +247,8 @@ return function(t)
                 runService = runServiceProbe,
             })
 
-            local remote2 = Harness.createRemote()
-            remotes2:Add(remote2)
+            local remoteContainer2 = Harness.createParryButtonPress({ scheduler = scheduler2 })
+            remotes2:Add(remoteContainer2)
 
             local autoparry2 = Harness.loadAutoparry({
                 scheduler = scheduler2,

--- a/tests/autoparry/evaluate_ball.spec.lua
+++ b/tests/autoparry/evaluate_ball.spec.lua
@@ -178,7 +178,7 @@ local function createContext()
         initialLocalPlayer = { Name = "LocalPlayer" },
     })
 
-    remotes:Add(Harness.createRemote())
+    remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
     local autoparry = Harness.loadAutoparry({
         scheduler = scheduler,

--- a/tests/autoparry/harness.lua
+++ b/tests/autoparry/harness.lua
@@ -234,7 +234,35 @@ function Harness.createRemote(options)
         error(string.format("Unsupported remote kind: %s", tostring(kind)))
     end
 
+    function remote:IsA(className)
+        return self.ClassName == className
+    end
+
     return remote
+end
+
+function Harness.createParryButtonPress(options)
+    options = options or {}
+    local scheduler = options.scheduler
+    if not scheduler then
+        error("createParryButtonPress requires a scheduler", 0)
+    end
+
+    local containerName = options.name or "ParryButtonPress"
+    local childName = options.childName or "parryButtonPress"
+    local container = createContainer(scheduler, containerName)
+    container.ClassName = options.className or "Folder"
+
+    local remote = Harness.createRemote({
+        kind = options.remoteKind or "BindableEvent",
+        name = childName,
+        className = options.remoteClassName,
+    })
+
+    container:Add(remote)
+    container._parryRemote = remote
+
+    return container, remote
 end
 
 function Harness.fireRemoteClient(remote, ...)

--- a/tests/autoparry/heartbeat.spec.lua
+++ b/tests/autoparry/heartbeat.spec.lua
@@ -130,20 +130,20 @@ return function(t)
             runService = runService,
         })
 
-        local remote = Harness.createRemote()
-        remotes:Add(remote)
+        local remoteContainer, remote = Harness.createParryButtonPress({ scheduler = scheduler })
+        remotes:Add(remoteContainer)
 
         local parryLog = {}
         local currentFrame = 0
 
-        local originalFireServer = remote.FireServer
-        remote.FireServer = function(self, ...)
+        local originalFire = remote.Fire
+        remote.Fire = function(self, ...)
             table.insert(parryLog, {
                 frame = currentFrame,
                 time = scheduler:clock(),
                 payload = { ... },
             })
-            return originalFireServer(self, ...)
+            return originalFire(self, ...)
         end
 
         local autoparry = Harness.loadAutoparry({

--- a/tests/autoparry/ping.spec.lua
+++ b/tests/autoparry/ping.spec.lua
@@ -64,7 +64,7 @@ return function(t)
             stats = stats,
         })
 
-        remotes:Add(Harness.createRemote())
+        remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
         local autoparry = Harness.loadAutoparry({
             scheduler = scheduler,

--- a/tests/autoparry/verification_status.spec.lua
+++ b/tests/autoparry/verification_status.spec.lua
@@ -32,7 +32,7 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            remotes:Add(Harness.createRemote())
+            remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -100,7 +100,7 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            remotes:Add(Harness.createRemote())
+            remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -161,8 +161,8 @@ return function(t)
         rawset(_G, "workspace", workspace)
 
         local ok, err = pcall(function()
-            local parryRemote = Harness.createRemote()
-            remotes:Add(parryRemote)
+            local parryContainer = Harness.createParryButtonPress({ scheduler = scheduler })
+            remotes:Add(parryContainer)
 
             local autoparry = Harness.loadAutoparry({
                 scheduler = scheduler,
@@ -177,11 +177,11 @@ return function(t)
             local ready = waitForStage(scheduler, autoparry, "ready")
             expect(ready.remoteName):toEqual("ParryButtonPress")
 
-            remotes:Remove(parryRemote.Name)
+            remotes:Remove(parryContainer.Name)
             scheduler:wait()
 
             scheduler:schedule(2, function()
-                remotes:Add(Harness.createRemote())
+                remotes:Add(Harness.createParryButtonPress({ scheduler = scheduler }))
             end)
 
             local readyAgain = waitForStage(scheduler, autoparry, "ready", 80)

--- a/tests/fixtures/place.project.json
+++ b/tests/fixtures/place.project.json
@@ -7,7 +7,10 @@
       "Remotes": {
         "$className": "Folder",
         "ParryButtonPress": {
-          "$className": "RemoteEvent"
+          "$className": "Folder",
+          "parryButtonPress": {
+            "$className": "BindableEvent"
+          }
         }
       },
       "TestHarness": {

--- a/tests/init.server.lua
+++ b/tests/init.server.lua
@@ -33,10 +33,11 @@ local function makeSignal()
 end
 
 local heartbeatSignal = makeSignal()
-local parryRemote = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+local parryContainer = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+local parryRemote = parryContainer:WaitForChild("parryButtonPress")
 local parryCalls = 0
 
-function parryRemote:FireServer(...)
+function parryRemote:Fire(...)
     parryCalls = parryCalls + 1
     self.LastPayload = { ... }
 end

--- a/tests/perf/heartbeat_benchmark.server.lua
+++ b/tests/perf/heartbeat_benchmark.server.lua
@@ -246,10 +246,11 @@ local function main()
         return originalGetService(self, name)
     end
 
-    local parryRemote = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+    local parryContainer = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+    local parryRemote = parryContainer:WaitForChild("parryButtonPress")
     local parryAttempts = 0
     local lastPayload
-    function parryRemote:FireServer(...)
+    function parryRemote:Fire(...)
         parryAttempts += 1
         lastPayload = { ... }
         return self

--- a/tests/perf/parry_accuracy.server.lua
+++ b/tests/perf/parry_accuracy.server.lua
@@ -322,15 +322,16 @@ function Environment.new(config)
     env.api.resetConfig()
     env.api.setEnabled(false)
 
-    env.parryRemote = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+    local parryContainer = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("ParryButtonPress")
+    env.parryRemote = parryContainer:WaitForChild("parryButtonPress")
     env.parryAttempts = 0
 
     local remote = env.parryRemote
-    local originalFireServer = remote.FireServer
-    env.originalFireServer = originalFireServer
+    local originalFire = remote.Fire
+    env.originalFire = originalFire
     local environment = env
 
-    function remote:FireServer(...)
+    function remote:Fire(...)
         environment.parryAttempts += 1
         local payload = { ... }
         table.insert(environment.remoteLog, {
@@ -339,7 +340,7 @@ function Environment.new(config)
             scenario = environment.currentScenario,
             payload = payload,
         })
-        return originalFireServer(self, ...)
+        return originalFire(self, ...)
     end
 
     env.parryConnection = env.api.onParry(function(ball, timestamp)
@@ -487,8 +488,8 @@ function Environment:cleanup()
         self.parryConnection = nil
     end
 
-    if self.parryRemote and self.originalFireServer then
-        self.parryRemote.FireServer = self.originalFireServer
+    if self.parryRemote and self.originalFire then
+        self.parryRemote.Fire = self.originalFire
     end
 
     if self.originalGetService then


### PR DESCRIPTION
## Summary
- enforce that verification locks onto ReplicatedStorage.Remotes.ParryButtonPress.parryButtonPress and guard against unsupported remotes
- call the parry bindable without payloads at runtime while keeping the harness, fixtures, and perf tests in sync with the BindableEvent structure
- refresh the packaged source map and place fixture so downstream consumers load the new ParryButtonPress folder layout

## Testing
- Not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68e555c59e58832a845d582ed27c9e5d