### PR TITLE
Harden loading overlay parent lookup

### DIFF
--- a/src/ui/loading_overlay.lua
+++ b/src/ui/loading_overlay.lua
@@ -210,14 +210,33 @@ local function mergeTheme(overrides)
     return theme
 end
 
+local function resolveScreenGuiParent(requestedParent)
+    if typeof(requestedParent) ~= "Instance" then
+        return CoreGui
+    end
+
+    local current = requestedParent
+    while current do
+        if current:IsA("CoreGui") or current:IsA("BasePlayerGui") then
+            return current
+        end
+
+        current = current.Parent
+    end
+
+    return CoreGui
+end
+
 local function createScreenGui(options)
+    local parent = resolveScreenGuiParent(options.parent)
+
     local gui = Instance.new("ScreenGui")
     gui.Name = options.name or "AutoParryLoadingOverlay"
     gui.DisplayOrder = 10_000
     gui.ResetOnSpawn = false
     gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
     gui.IgnoreGuiInset = true
-    gui.Parent = options.parent or CoreGui
+    gui.Parent = parent
     return gui
 end
 

--- a/tests/fixtures/AutoParrySourceMap.lua
+++ b/tests/fixtures/AutoParrySourceMap.lua
@@ -3929,14 +3929,33 @@ local function mergeTheme(overrides)
     return theme
 end
 
+local function resolveScreenGuiParent(requestedParent)
+    if typeof(requestedParent) ~= "Instance" then
+        return CoreGui
+    end
+
+    local current = requestedParent
+    while current do
+        if current:IsA("CoreGui") or current:IsA("BasePlayerGui") then
+            return current
+        end
+
+        current = current.Parent
+    end
+
+    return CoreGui
+end
+
 local function createScreenGui(options)
+    local parent = resolveScreenGuiParent(options.parent)
+
     local gui = Instance.new("ScreenGui")
     gui.Name = options.name or "AutoParryLoadingOverlay"
     gui.DisplayOrder = 10_000
     gui.ResetOnSpawn = false
     gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
     gui.IgnoreGuiInset = true
-    gui.Parent = options.parent or CoreGui
+    gui.Parent = parent
     return gui
 end
 


### PR DESCRIPTION
## Summary
- walk up the requested parent chain until a CoreGui or BasePlayerGui ancestor is found before creating the loading overlay
- sync the source map fixture with the stricter parent resolution logic

## Testing
- selene src *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e5aea2b354832aa2b88e4c2a75242e