### PR TITLE
Improve loading overlay parent resolution

### DIFF
--- a/tests/fixtures/AutoParrySourceMap.lua
+++ b/tests/fixtures/AutoParrySourceMap.lua
@@ -2360,6 +2360,7 @@ return Util
 -- downstream experiences room to customise the presentation.
 
 local CoreGui = game:GetService("CoreGui")
+local Players = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
 
 local Require = rawget(_G, "ARequire")
@@ -3929,14 +3930,62 @@ local function mergeTheme(overrides)
     return theme
 end
 
+local function isValidScreenGuiContainer(instance)
+    if not instance then
+        return false
+    end
+
+    if instance:IsA("ScreenGui") then
+        return false
+    end
+
+    if instance:IsA("CoreGui") or instance:IsA("BasePlayerGui") or instance:IsA("PluginGui") then
+        return true
+    end
+
+    local ok, isLayerCollector = pcall(function()
+        return instance:IsA("LayerCollector")
+    end)
+    if ok and isLayerCollector then
+        return true
+    end
+
+    return false
+end
+
+local function resolveScreenGuiParent(requestedParent)
+    if typeof(requestedParent) == "Instance" then
+        local current = requestedParent
+        while current do
+            if isValidScreenGuiContainer(current) then
+                return current
+            end
+
+            current = current.Parent
+        end
+    end
+
+    local localPlayer = Players.LocalPlayer
+    if localPlayer then
+        local playerGui = localPlayer:FindFirstChildOfClass("PlayerGui")
+        if playerGui and isValidScreenGuiContainer(playerGui) then
+            return playerGui
+        end
+    end
+
+    return CoreGui
+end
+
 local function createScreenGui(options)
+    local parent = resolveScreenGuiParent(options.parent)
+
     local gui = Instance.new("ScreenGui")
     gui.Name = options.name or "AutoParryLoadingOverlay"
     gui.DisplayOrder = 10_000
     gui.ResetOnSpawn = false
     gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
     gui.IgnoreGuiInset = true
-    gui.Parent = options.parent or CoreGui
+    gui.Parent = parent
     return gui
 end
 


### PR DESCRIPTION
## Summary
- tighten the loading overlay parent resolution to only use valid LayerCollector ancestors and skip nested ScreenGuis
- fall back to the local player's PlayerGui when no explicit parent chain resolves to a valid container
- mirror the refined resolver logic in the AutoParry source map fixture

## Testing
- not run (selene not available)

------
https://chatgpt.com/codex/tasks/task_b_68e5aea2b354832aa2b88e4c2a75242e