### PR TITLE
Ensure dashboard resize recomputes layout bounds

### DIFF
--- a/src/ui/verification_dashboard.lua
+++ b/src/ui/verification_dashboard.lua
@@ -1695,7 +1695,7 @@ function VerificationDashboard:_installResponsiveHandlers()
         if self._destroyed then
             return
         end
-        self:updateLayout(self._lastLayoutBounds)
+        self:updateLayout(self:_resolveBoundsFromRoot())
     end)
     table.insert(self._connections, connection)
 
@@ -1703,8 +1703,33 @@ function VerificationDashboard:_installResponsiveHandlers()
         if self._destroyed then
             return
         end
-        self:updateLayout(self._lastLayoutBounds)
+        self:updateLayout(self:_resolveBoundsFromRoot())
     end)
+end
+
+function VerificationDashboard:_resolveBoundsFromRoot()
+    local root = self._root
+    if not root then
+        return self._lastLayoutBounds
+    end
+
+    local size = root.AbsoluteSize
+    local width = math.floor((size and size.X) or 0)
+    if width <= 0 then
+        return self._lastLayoutBounds
+    end
+
+    local height = math.floor((size and size.Y) or 0)
+    local last = self._lastLayoutBounds
+
+    return {
+        mode = last and last.mode or nil,
+        containerWidth = width,
+        containerHeight = (last and last.containerHeight) or height,
+        dashboardWidth = width,
+        dashboardHeight = (last and last.dashboardHeight) or height,
+        contentWidth = last and last.contentWidth,
+    }
 end
 
 function VerificationDashboard:_applyResponsiveLayout(width, bounds)


### PR DESCRIPTION
## Summary
- derive responsive layout bounds from the dashboard root before recalculating layout
- reuse the derived bounds for deferred layout refresh after installing responsive handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e670c158e8832aab0c66095af0e6c7